### PR TITLE
[TECHNICAL-SUPPORT] 	LPS-70145 Escape all of the reserved characters according to RFC3986

### DIFF
--- a/modules/apps/collaboration/wiki/wiki-api/src/main/java/com/liferay/wiki/escape/WikiEscapeUtil.java
+++ b/modules/apps/collaboration/wiki/wiki-api/src/main/java/com/liferay/wiki/escape/WikiEscapeUtil.java
@@ -30,10 +30,21 @@ public class WikiEscapeUtil {
 		return StringUtil.replace(name, _ESCAPED_CHARS, _UNESCAPED_CHARS);
 	}
 
-	private static final String[] _ESCAPED_CHARS =
-		new String[] {"<PLUS>", "<QUESTION>", "<SLASH>"};
+	private static final String[] _ESCAPED_CHARS = new String[] {
+		"<AMPERSAND>", "<APOSTROPHE>", "<AT>", "<CLOSE_BRACKET>",
+		"<CLOSE_PARENTHESIS>", "<COLON>", "<COMMA>", "<DOLLAR>", "<EQUAL>",
+		"<EXCLAMATION>", "<OPEN_BRACKET>", "<OPEN_PARENTHESIS>", "<PLUS>",
+		"<POUND>", "<QUESTION>", "<SEMICOLON>", "<SLASH>", "<STAR>"
+	};
 
-	private static final String[] _UNESCAPED_CHARS =
-		new String[] {StringPool.PLUS, StringPool.QUESTION, StringPool.SLASH};
+	private static final String[] _UNESCAPED_CHARS = new String[] {
+		StringPool.AMPERSAND, StringPool.APOSTROPHE, StringPool.AT,
+		StringPool.CLOSE_BRACKET, StringPool.CLOSE_PARENTHESIS,
+		StringPool.COLON, StringPool.COMMA, StringPool.DOLLAR, StringPool.EQUAL,
+		StringPool.EXCLAMATION, StringPool.OPEN_BRACKET,
+		StringPool.OPEN_PARENTHESIS, StringPool.PLUS, StringPool.POUND,
+		StringPool.QUESTION, StringPool.SEMICOLON, StringPool.SLASH,
+		StringPool.STAR
+	};
 
 }

--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/.gitrepo
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = b1ce2c893c2ded2572cbeb14e87bd251638f0200
+	commit = 34db57adf155954c462315d7c4e3bc8f97c774fd
 	mode = push
-	parent = d7ff79ac2055fd1979321ef9fec465a77d830b3a
+	parent = a7ac0ac8cc832c8f533e7c275ad5e86b55f5d319
 	remote = git@github.com:liferay/com-liferay-dynamic-data-mapping.git

--- a/modules/apps/foundation/frontend-js/.gitrepo
+++ b/modules/apps/foundation/frontend-js/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = f6a87034e461bccc0fac44ddaa74c182bac8283a
+	commit = 7e53578a953b9522002b5045fce5bd0517680928
 	mode = push
-	parent = 933758b32e4911ec6f210a4b5b28289edf598f8a
+	parent = 7c8bf1313c9736c9e7219b8d39981ebf5e0d77ad
 	remote = git@github.com:liferay/com-liferay-frontend-js.git

--- a/modules/apps/foundation/hello-soy/.gitrepo
+++ b/modules/apps/foundation/hello-soy/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 555116a9f56e63dc20f0e0b0b657f859dbc15d0b
+	commit = 37030800f50bb77c3f32e5990bb3a0ac2b580c38
 	mode = push
-	parent = 4632e5c327c0181b15f60c3fe0e21cfc726c711b
+	parent = 68279bd5fcf9789d33df1d7a832946d32d61c29e
 	remote = git@github.com:liferay/com-liferay-hello-soy.git

--- a/modules/apps/foundation/login/.gitrepo
+++ b/modules/apps/foundation/login/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 272b14fd831a9b82b9cf0635a78de446e0c0b8fe
+	commit = 8f64bbf38bbaf0354bce26c89f3c8a2e77e4745b
 	mode = push
-	parent = 830f07ab548903da38fa9fa8ffe19d5264e0931a
+	parent = 6328c0b25ac1745c99e691d8ac937befe35ef760
 	remote = git@github.com:liferay/com-liferay-login.git

--- a/modules/apps/foundation/portal-search/.gitrepo
+++ b/modules/apps/foundation/portal-search/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 8e5df9ded9385e5f816c4ff0eebcf35ec98f3e61
+	commit = c950b26e7e082bce04c05cf31ea7e6345f49fff4
 	mode = push
-	parent = 240600f5a151027e73176bba5e368438617cc47c
+	parent = f0a226c09587c76fb60bb1b4ab3d29df95510602
 	remote = git@github.com:liferay/com-liferay-portal-search.git

--- a/modules/apps/marketplace/.gitrepo
+++ b/modules/apps/marketplace/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = f25afcf38ab7dc8530eda0d1ece97a78fd76f6d6
+	commit = 85114d1f8ac1049f9064cc2566df8e5b64c137ce
 	mode = push
-	parent = 5f2181d536ee615d28ae84962cc753c5dcee497f
+	parent = 8dbd22a99f7aa659b6b0ebc9251b35618d139683
 	remote = git@github.com:liferay/com-liferay-marketplace.git

--- a/modules/apps/web-experience/export-import/.gitrepo
+++ b/modules/apps/web-experience/export-import/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 43b57c863822ae68347ae9d4a00e134aaab4b6ff
+	commit = 66774f807b805b5283ca2a24d490869c431a281f
 	mode = push
-	parent = 191b9f0d09aeeb8a8ff8777f9b9a860295ba4731
+	parent = c3204cbf84cf8b6d61bef95001d1ff6aae0a5fc1
 	remote = git@github.com:liferay/com-liferay-export-import.git

--- a/modules/apps/web-experience/layout/.gitrepo
+++ b/modules/apps/web-experience/layout/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 8f82e832c6a6e581bbc54d1cbc75dc92f4a6ee4e
+	commit = 7006b93228cc55e7ce755180143d40db511d7a6d
 	mode = push
-	parent = 05f9e183cf569404fed5c9d49be6541e7282eba1
+	parent = f0de1eb11c966251264ff67a49fcb8b9cbda0717
 	remote = git@github.com:liferay/com-liferay-layout.git

--- a/modules/apps/web-experience/site/.gitrepo
+++ b/modules/apps/web-experience/site/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = d4bf83af8112f65cabe4946ae3bc31ba7217061e
+	commit = 3b32a0895dc33752bf134b58206036cae3fcc5a7
 	mode = push
-	parent = 0f538ffb2d84eb222b4e361e0bcfcdeaeb930f27
+	parent = f5a13168117b6a2ade16df02758343037740d20c
 	remote = git@github.com:liferay/com-liferay-site.git


### PR DESCRIPTION
Hi Alejandro,

this issue is about escaping special characters in Wiki Page titles, because it's possible that the **VirtualHostFilter** fails when there is a special character in the title.

I think a more general solution would be to create a new column ( e.g. urlTitle)  in the wikipage table, like what we have for Web Contents, so we could normalize the title properly.

However, as it would require schema modification, I don't think that we could handle it as a bug and backport it to 7.

Therefore I looked for alternative solutions and found **WikiEscapeUtil**, where a few special characters are already handled.
I extended the list, according to [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.2).

Could you please review my changes?

Thanks!
Tamás