### PR TITLE
LPS-73691 SF

### DIFF
--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
@@ -108,11 +108,10 @@ public class NotificationsPortlet extends MVCPortlet {
 					UserNotificationDeliveryConstants.TYPE_WEBSITE, false,
 					false);
 
-		for (UserNotificationEvent notification : userNotificationEvents) {
-			notification.setArchived(true);
+		for (UserNotificationEvent userNotificationEvent :
+				userNotificationEvents) {
 
-			_userNotificationEventLocalService.updateUserNotificationEvent(
-				notification);
+			updateArchived(userNotificationEvent);
 		}
 
 		ResourceBundle resourceBundle =
@@ -277,6 +276,12 @@ public class NotificationsPortlet extends MVCPortlet {
 		if (userNotificationEvent == null) {
 			return;
 		}
+
+		updateArchived(userNotificationEvent);
+	}
+
+	protected void updateArchived(UserNotificationEvent userNotificationEvent)
+		throws Exception {
 
 		userNotificationEvent.setArchived(true);
 

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
@@ -17,6 +17,7 @@ package com.liferay.notifications.web.internal.portlet;
 import com.liferay.notifications.web.internal.constants.NotificationsPortletKeys;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Release;
+import com.liferay.portal.kernel.model.UserNotificationDeliveryConstants;
 import com.liferay.portal.kernel.model.UserNotificationEvent;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.service.UserNotificationDeliveryLocalService;
@@ -29,6 +30,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.subscription.service.SubscriptionLocalService;
 
+import java.util.List;
 import java.util.ResourceBundle;
 
 import javax.portlet.ActionRequest;
@@ -95,6 +97,23 @@ public class NotificationsPortlet extends MVCPortlet {
 	public void markAllNotificationsAsRead(
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		List<UserNotificationEvent> userNotificationEvents =
+			_userNotificationEventLocalService.
+				getArchivedUserNotificationEvents(
+					themeDisplay.getUserId(),
+					UserNotificationDeliveryConstants.TYPE_WEBSITE, false,
+					false);
+
+		for (UserNotificationEvent notification : userNotificationEvents) {
+			notification.setArchived(true);
+
+			_userNotificationEventLocalService.updateUserNotificationEvent(
+				notification);
+		}
 	}
 
 	public void markAsRead(

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
@@ -122,7 +122,7 @@ public class NotificationsPortlet extends MVCPortlet {
 			actionRequest, "requestProcessed",
 			LanguageUtil.get(
 				resourceBundle,
-				"all-notifications-were-marked-as-read-sucessfully"));
+				"all-notifications-were-marked-as-read-successfully"));
 	}
 
 	public void markAsRead(

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
@@ -92,6 +92,11 @@ public class NotificationsPortlet extends MVCPortlet {
 		}
 	}
 
+	public void markAllNotificationsAsRead(
+			ActionRequest actionRequest, ActionResponse actionResponse)
+		throws Exception {
+	}
+
 	public void markAsRead(
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/NotificationsPortlet.java
@@ -114,6 +114,15 @@ public class NotificationsPortlet extends MVCPortlet {
 			_userNotificationEventLocalService.updateUserNotificationEvent(
 				notification);
 		}
+
+		ResourceBundle resourceBundle =
+			_resourceBundleLoader.loadResourceBundle(themeDisplay.getLocale());
+
+		SessionMessages.add(
+			actionRequest, "requestProcessed",
+			LanguageUtil.get(
+				resourceBundle,
+				"all-notifications-were-marked-as-read-sucessfully"));
 	}
 
 	public void markAsRead(

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/configuration/icon/MarkAsReadPortletConfigurationIcon.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/configuration/icon/MarkAsReadPortletConfigurationIcon.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.notifications.web.internal.portlet.configuration.icon;
+
+import com.liferay.notifications.web.internal.constants.NotificationsPortletKeys;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
+import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletResponse;
+
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import org.osgi.service.component.annotations.Component;
+
+import java.util.ResourceBundle;
+
+/**
+ * @author Alejandro Tardín
+ */
+@Component(
+	immediate = true,
+	property = {"javax.portlet.name=" + NotificationsPortletKeys.NOTIFICATIONS},
+	service = PortletConfigurationIcon.class
+)
+public class MarkAsReadPortletConfigurationIcon
+	extends BasePortletConfigurationIcon {
+
+	@Override
+	public String getMessage(PortletRequest portletRequest) {
+		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
+			"content.Language", getLocale(portletRequest), getClass());
+
+		return LanguageUtil.get(
+			resourceBundle, "mark-all-notifications-as-read");
+	}
+
+	@Override
+	public String getURL(
+		PortletRequest portletRequest, PortletResponse portletResponse) {
+
+		return "http://localhost:8080";
+	}
+
+	@Override
+	public boolean isShow(PortletRequest portletRequest) {
+		return true;
+	}
+
+	@Override
+	public boolean isToolTip() {
+		return false;
+	}
+
+}

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/configuration/icon/MarkAsReadPortletConfigurationIcon.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/configuration/icon/MarkAsReadPortletConfigurationIcon.java
@@ -16,6 +16,7 @@ package com.liferay.notifications.web.internal.portlet.configuration.icon;
 
 import com.liferay.notifications.web.internal.constants.NotificationsPortletKeys;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -23,8 +24,10 @@ import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import java.util.ResourceBundle;
 
+import javax.portlet.ActionRequest;
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
+import javax.portlet.PortletURL;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -52,7 +55,14 @@ public class MarkAsReadPortletConfigurationIcon
 	public String getURL(
 		PortletRequest portletRequest, PortletResponse portletResponse) {
 
-		return "http://localhost:8080";
+		PortletURL portletURL = PortletURLFactoryUtil.create(
+			portletRequest, NotificationsPortletKeys.NOTIFICATIONS,
+			PortletRequest.ACTION_PHASE);
+
+		portletURL.setParameter(
+			ActionRequest.ACTION_NAME, "markAllNotificationsAsRead");
+
+		return portletURL.toString();
 	}
 
 	@Override

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/configuration/icon/MarkAsReadPortletConfigurationIcon.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/configuration/icon/MarkAsReadPortletConfigurationIcon.java
@@ -18,14 +18,15 @@ import com.liferay.notifications.web.internal.constants.NotificationsPortletKeys
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
+
+import java.util.ResourceBundle;
 
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import org.osgi.service.component.annotations.Component;
-
-import java.util.ResourceBundle;
 
 /**
  * @author Alejandro Tardín
@@ -56,7 +57,7 @@ public class MarkAsReadPortletConfigurationIcon
 
 	@Override
 	public boolean isShow(PortletRequest portletRequest) {
-		return true;
+		return !ParamUtil.getBoolean(portletRequest, "actionRequired");
 	}
 
 	@Override

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/configuration/icon/MarkAsReadPortletConfigurationIcon.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/portlet/configuration/icon/MarkAsReadPortletConfigurationIcon.java
@@ -16,11 +16,15 @@ package com.liferay.notifications.web.internal.portlet.configuration.icon;
 
 import com.liferay.notifications.web.internal.constants.NotificationsPortletKeys;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.UserNotificationDeliveryConstants;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.configuration.icon.BasePortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
+import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.ResourceBundle;
 
@@ -30,6 +34,7 @@ import javax.portlet.PortletResponse;
 import javax.portlet.PortletURL;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Alejandro Tardín
@@ -67,12 +72,33 @@ public class MarkAsReadPortletConfigurationIcon
 
 	@Override
 	public boolean isShow(PortletRequest portletRequest) {
-		return !ParamUtil.getBoolean(portletRequest, "actionRequired");
+		if (!ParamUtil.getBoolean(portletRequest, "actionRequired")) {
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)portletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
+			int unreadNotificationEventsCount =
+				_userNotificationEventLocalService.
+					getArchivedUserNotificationEventsCount(
+						themeDisplay.getUserId(),
+						UserNotificationDeliveryConstants.TYPE_WEBSITE, false,
+						false);
+
+			if (unreadNotificationEventsCount > 0) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	@Override
 	public boolean isToolTip() {
 		return false;
 	}
+
+	@Reference
+	private UserNotificationEventLocalService
+		_userNotificationEventLocalService;
 
 }

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/resources/content/Language.properties
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/resources/content/Language.properties
@@ -1,3 +1,4 @@
+all-notifications-were-marked-as-read-sucessfully=All notifications were marked as read successfully
 javax.portlet.title.com_liferay_notifications_web_portlet_NotificationsPortlet=Notifications
 mark-all-notifications-as-read=Mark all notifications as read
 notifications-list=Notifications List

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/resources/content/Language.properties
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/resources/content/Language.properties
@@ -1,4 +1,4 @@
-all-notifications-were-marked-as-read-sucessfully=All notifications were marked as read successfully
+all-notifications-were-marked-as-read-successfully=All notifications were marked as read successfully.
 javax.portlet.title.com_liferay_notifications_web_portlet_NotificationsPortlet=Notifications
 mark-all-notifications-as-read=Mark all notifications as read
 notifications-list=Notifications List

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/resources/content/Language.properties
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/resources/content/Language.properties
@@ -1,4 +1,5 @@
 javax.portlet.title.com_liferay_notifications_web_portlet_NotificationsPortlet=Notifications
+mark-all-notifications-as-read=Mark all notifications as read
 notifications-list=Notifications List
 receive-a-notification-when-someone=Receive a notification when someone:
 requests-list=Requests List


### PR DESCRIPTION
Faltaría cambiar los nombres de los métodos en NotificationsPortlet:
markAsRead -> markNotificationAsRead
markAllAsRead -> markNotificationsAsRead

En la implementación del método markAllNotificationsAsRead utilizar la clase IntervalActionProcessor para evitar cargar potencialmente muchos UserNotificationEvent en memoria.

Gracias!