### PR TITLE
LPS-79998

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-js-web/src/main/resources/META-INF/resources/ckeditor/plugins/adaptivemedia/plugin.js
+++ b/modules/apps/adaptive-media/adaptive-media-image-js-web/src/main/resources/META-INF/resources/ckeditor/plugins/adaptivemedia/plugin.js
@@ -120,7 +120,12 @@
 					el = instance._getImgElement(imageSrc, selectedItem, fileEntryAttributeName);
 				}
 
+				var firstLineBreak = CKEDITOR.dom.element.createFromHtml('<br>');
+				var secondLineBreak = CKEDITOR.dom.element.createFromHtml('<br>');
+
 				editor.insertElement(el);
+				editor.insertElement(firstLineBreak);
+				editor.insertElement(secondLineBreak);
 
 				editor.setData(editor.getData());
 			}

--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/editor_image_uploader.js
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/editor_image_uploader.js
@@ -206,11 +206,7 @@ AUI.add(
 
 								imageContainer.remove();
 
-								var outernode = image._node.outerHTML;
-
-								outernode += '<br><br>';
-
-								image._node.outerHTML = outernode;
+								image._node.outerHTML += '<br><br>';
 
 								editor.fire(
 									'imageUploaded',

--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/editor_image_uploader.js
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/editor_image_uploader.js
@@ -206,6 +206,12 @@ AUI.add(
 
 								imageContainer.remove();
 
+								var outernode = image._node.outerHTML;
+
+								outernode += '<br><br>';
+
+								image._node.outerHTML = outernode;
+
 								editor.fire(
 									'imageUploaded',
 									{

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -397,8 +397,12 @@
 								}
 								else {
 									var el = CKEDITOR.dom.element.createFromHtml('<img src="' + imageSrc + '">');
+									var firstLineBreak = CKEDITOR.dom.element.createFromHtml('<br>');
+									var secondLineBreak = CKEDITOR.dom.element.createFromHtml('<br>');
 
 									editor.insertElement(el);
+									editor.insertElement(firstLineBreak);
+									editor.insertElement(secondLineBreak);
 
 									editor.focus();
 								}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-79998

When adding an image that is wider than the blog's editor, the image will be resized to fit the editor. With this resizing, it will not be possible for the user to add text below the image without having to resize the image first. To fix this issue, I have added line breaks so that the user will no longer have to resize the image before adding more text.

If the image is the first content added, it will create two break lines making it easier for the user to click below the image. When the image is added with previous content, it will create one break line after the image. It seems that the previous content would discard the first break line but will render the second break line still making it possible for the user to add content. I can see that this could be an area of improvement and will be willing to work on it more if needed.

Notes on two line breaks.
Reason why changes to [`35c6186 `](https://github.com/sergiogonzalez/liferay-portal/commit/35c618629ab504d61d4c556baad9838e8984e798)are different is because of an issue where in normal use the break lines are added to the editor before the image is added.
[Having two line break elements](https://github.com/jonathanmccann/liferay-portal/pull/1636#issuecomment-395484341)

If you have any questions or comments please let me know.
Thank you!