### PR TITLE
LPS-135132 Enabling check in site settings doesn't work when it's unchecked in Instance settings > Site scope

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/portlet/action/BindConfigurationMVCActionCommand.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/portlet/action/BindConfigurationMVCActionCommand.java
@@ -120,7 +120,10 @@ public class BindConfigurationMVCActionCommand implements MVCActionCommand {
 				pid, configurationScopeDisplayContext.getScope(),
 				configurationScopeDisplayContext.getScopePK());
 
-		if (configurationModel.isFactory() && pid.equals(factoryPid)) {
+		if ((configurationModel.isFactory() && pid.equals(factoryPid)) ||
+			!configurationModel.hasScopeConfiguration(
+				configurationScopeDisplayContext.getScope())) {
+
 			configuration = null;
 		}
 

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationModelRetrieverImpl.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationModelRetrieverImpl.java
@@ -384,7 +384,8 @@ public class ConfigurationModelRetrieverImpl
 
 		return getAndFilterString(
 			getPropertyFilterString(
-				ConfigurationAdmin.SERVICE_FACTORYPID, pid + ".scoped"),
+				ConfigurationAdmin.SERVICE_FACTORYPID,
+				getUnscopedPid(pid) + ".scoped"),
 			getPropertyFilterString(
 				scope.getPropertyKey(), String.valueOf(scopePK)));
 	}
@@ -397,6 +398,10 @@ public class ConfigurationModelRetrieverImpl
 		return StringBundler.concat(
 			StringPool.OPEN_PARENTHESIS, key, StringPool.EQUAL, value,
 			StringPool.CLOSE_PARENTHESIS);
+	}
+
+	protected String getUnscopedPid(String pid) {
+		return pid.replaceFirst("\\.scoped.*", StringPool.BLANK);
 	}
 
 	private BundleContext _bundleContext;


### PR DESCRIPTION
This is an update for [LPS-135132](https://issues.liferay.com/browse/LPS-135132).<br/><br/>Hi @4lejandrito, will you please review this change to see if it fixes your issue\? It contains the same string replacement logic, but used in a different spot. The main difference here is that if we determine that a configuration has not been saved at the current scope, we discard the found configuration. Please let me know if you have any question or concerns. Thanks!<br/><br/>/cc @pei-jung @alee8888