### PR TITLE
pr brian

### DIFF
--- a/modules/apps/analytics/analytics-dxp-entity-rest-impl/build.gradle
+++ b/modules/apps/analytics/analytics-dxp-entity-rest-impl/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
 	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:analytics:analytics-dxp-entity-rest-api")

--- a/modules/apps/analytics/analytics-dxp-entity-rest-impl/src/main/java/com/liferay/analytics/dxp/entity/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/analytics/analytics-dxp-entity-rest-impl/src/main/java/com/liferay/analytics/dxp/entity/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -58,19 +60,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -58,19 +60,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -58,19 +60,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -59,19 +61,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/rest-openapi.yaml
@@ -1551,7 +1551,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Catalog API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.21'."
+        artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.22'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -48,7 +50,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.21'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Catalog API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.22'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Catalog API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {
@@ -59,19 +61,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -59,19 +61,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -59,19 +61,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/rest-openapi.yaml
@@ -1360,7 +1360,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Order API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.22'."
+        artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.23'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -48,7 +50,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Order API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.22'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Order API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Order API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.23'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Order API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {
@@ -59,19 +61,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -59,19 +61,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -59,19 +61,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -59,19 +61,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -59,19 +61,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -59,19 +61,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -59,19 +61,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/src/main/java/com/liferay/headless/commerce/delivery/order/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -59,19 +61,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/OpenAPIResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -58,19 +60,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -58,19 +60,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-impl/src/main/java/com/liferay/frontend/view/state/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-impl/src/main/java/com/liferay/frontend/view/state/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -58,19 +60,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -58,19 +60,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-openapi.yaml
@@ -186,7 +186,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.content.client', and version '2.0.17'."
+        'com.liferay.headless.admin.content.client', and version '2.0.18'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -47,7 +49,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.content.client', and version '2.0.17'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Content", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.content.client', and version '2.0.18'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Content", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {
@@ -58,19 +60,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -58,19 +60,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -58,19 +60,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -58,19 +60,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -58,19 +60,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -58,19 +60,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -5302,7 +5302,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.delivery.client', and version '4.0.38'."
+        'com.liferay.headless.delivery.client', and version '4.0.39'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -47,7 +49,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.38'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.39'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {
@@ -58,19 +60,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/headless/headless-discovery/headless-discovery-impl/src/main/java/com/liferay/headless/discovery/internal/jaxrs/application/HeadlessDiscoveryOpenAPIApplication.java
+++ b/modules/apps/headless/headless-discovery/headless-discovery-impl/src/main/java/com/liferay/headless/discovery/internal/jaxrs/application/HeadlessDiscoveryOpenAPIApplication.java
@@ -15,8 +15,8 @@
 package com.liferay.headless.discovery.internal.jaxrs.application;
 
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.vulcan.util.UriInfoUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -33,7 +33,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
 import org.osgi.service.component.annotations.Component;
@@ -66,13 +65,12 @@ public class HeadlessDiscoveryOpenAPIApplication extends Application {
 	@GET
 	@Produces({"application/json", "application/xml"})
 	public Map<String, List<String>> openAPI(
-		@HeaderParam("Accept") String accept,
-		@HeaderParam("X-Forwarded-Host") String xForwardedHost,
-		@HeaderParam("X-Forwarded-Proto") String xForwardedProto) {
+		@HeaderParam("Accept") String accept) {
 
 		Map<String, List<String>> pathsMap = new TreeMap<>();
 
-		String serverURL = _getServerURL(xForwardedHost, xForwardedProto);
+		String serverURL =
+			_portal.getPortalURL(_httpServletRequest) + Portal.PATH_MODULE;
 
 		RuntimeDTO runtimeDTO = _jaxrsServiceRuntime.getRuntimeDTO();
 
@@ -125,33 +123,14 @@ public class HeadlessDiscoveryOpenAPIApplication extends Application {
 		}
 	}
 
-	private String _getServerURL(
-		String xForwardedHost, String xForwardedProto) {
-
-		String absolutePath;
-
-		if ((xForwardedHost != null) && (xForwardedProto != null)) {
-			UriBuilder uriBuilder = _uriInfo.getAbsolutePathBuilder();
-
-			absolutePath = String.valueOf(
-				uriBuilder.host(
-					xForwardedHost
-				).scheme(
-					xForwardedProto
-				).build());
-		}
-		else {
-			absolutePath = UriInfoUtil.getAbsolutePath(_uriInfo);
-		}
-
-		return StringUtil.removeSubstring(absolutePath, "/openapi/");
-	}
-
 	@Context
 	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private JaxrsServiceRuntime _jaxrsServiceRuntime;
+
+	@Reference
+	private Portal _portal;
 
 	@Context
 	private UriInfo _uriInfo;

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -58,19 +60,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -58,19 +60,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -58,19 +60,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -58,19 +60,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -58,19 +60,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Vulcan API
 Bundle-SymbolicName: com.liferay.portal.vulcan.api
-Bundle-Version: 15.1.2
+Bundle-Version: 15.2.0
 Export-Package:\
 	com.liferay.portal.vulcan.accept.language,\
 	com.liferay.portal.vulcan.aggregation,\

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/resource/OpenAPIResource.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/resource/OpenAPIResource.java
@@ -19,6 +19,7 @@ import com.liferay.portal.vulcan.openapi.OpenAPISchemaFilter;
 import java.util.Set;
 
 import javax.servlet.ServletConfig;
+import javax.servlet.http.HttpServletRequest;
 
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.HttpHeaders;
@@ -38,6 +39,11 @@ public interface OpenAPIResource {
 
 		return getOpenAPI(resourceClasses, type);
 	}
+
+	public Response getOpenAPI(
+			HttpServletRequest httpServletRequest,
+			Set<Class<?>> resourceClasses, String type, UriInfo uriInfo)
+		throws Exception;
 
 	public default Response getOpenAPI(
 			OpenAPISchemaFilter openAPISchemaFilter,

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/UriInfoUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/UriInfoUtil.java
@@ -37,6 +37,20 @@ public class UriInfoUtil {
 			).build());
 	}
 
+	public static String getBasePath(
+		String host, String scheme, UriInfo uriInfo) {
+
+		UriBuilder uriBuilder = getBaseUriBuilder(uriInfo);
+
+		uriBuilder.host(
+			host
+		).scheme(
+			scheme
+		);
+
+		return String.valueOf(uriBuilder.build());
+	}
+
 	public static String getBasePath(UriInfo uriInfo) {
 		return String.valueOf(
 			getBaseUriBuilder(

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/resource/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/resource/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.4.0

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/util/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.5.0
+version 3.6.0

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/OpenAPIResourceImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/OpenAPIResourceImpl.java
@@ -17,8 +17,10 @@ package com.liferay.portal.vulcan.internal.resource;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
@@ -70,6 +72,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
@@ -89,98 +93,22 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 
 	@Override
 	public Response getOpenAPI(
+			HttpServletRequest httpServletRequest,
+			Set<Class<?>> resourceClasses, String type, UriInfo uriInfo)
+		throws Exception {
+
+		return _getOpenAPI(
+			httpServletRequest, null, resourceClasses, type, uriInfo);
+	}
+
+	@Override
+	public Response getOpenAPI(
 			OpenAPISchemaFilter openAPISchemaFilter,
 			Set<Class<?>> resourceClasses, String type, UriInfo uriInfo)
 		throws Exception {
 
-		JaxrsOpenApiContextBuilder jaxrsOpenApiContextBuilder =
-			new JaxrsOpenApiContextBuilder();
-
-		OpenApiContext openApiContext = jaxrsOpenApiContextBuilder.buildContext(
-			true);
-
-		GenericOpenApiContext genericOpenApiContext =
-			(GenericOpenApiContext)openApiContext;
-
-		genericOpenApiContext.setCacheTTL(0L);
-		genericOpenApiContext.setOpenApiScanner(
-			new OpenApiScanner() {
-
-				@Override
-				public Set<Class<?>> classes() {
-					return resourceClasses;
-				}
-
-				@Override
-				public Map<String, Object> resources() {
-					return new HashMap<>();
-				}
-
-				@Override
-				public void setConfiguration(
-					OpenAPIConfiguration openAPIConfiguration) {
-				}
-
-			});
-
-		OpenAPI openAPI = openApiContext.read();
-
-		OpenAPISchemaFilter mergedOpenAPISchemaFilter =
-			_mergeOpenAPISchemaFilters(
-				openAPISchemaFilter,
-				_getOpenAPISchemaFilter(
-					_getBasePath(uriInfo), _extensionProviderRegistry,
-					resourceClasses));
-
-		if (mergedOpenAPISchemaFilter != null) {
-			SpecFilter specFilter = new SpecFilter();
-
-			Map<String, List<String>> queryParameters = null;
-
-			if (uriInfo != null) {
-				queryParameters = uriInfo.getQueryParameters();
-			}
-
-			openAPI = specFilter.filter(
-				openAPI, _toOpenAPISpecFilter(mergedOpenAPISchemaFilter),
-				queryParameters, null, null);
-		}
-
-		if (openAPI == null) {
-			return Response.status(
-				404
-			).build();
-		}
-
-		if (uriInfo != null) {
-			Server server = new Server();
-
-			server.setUrl(_getBasePath(uriInfo));
-
-			openAPI.setServers(Collections.singletonList(server));
-		}
-
-		for (OpenAPIContributor openAPIContributor : _openAPIContributors) {
-			openAPIContributor.contribute(openAPI, uriInfo);
-		}
-
-		if (StringUtil.equalsIgnoreCase("yaml", type)) {
-			return Response.status(
-				Response.Status.OK
-			).entity(
-				Yaml.pretty(openAPI)
-			).type(
-				"application/yaml"
-			).build();
-		}
-
-		return Response.status(
-			Response.Status.OK
-		).entity(
-			openAPI
-		).type(
-			MediaType.APPLICATION_JSON_TYPE
-		).build();
+		return _getOpenAPI(
+			null, openAPISchemaFilter, resourceClasses, type, uriInfo);
 	}
 
 	@Override
@@ -195,7 +123,7 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 			Set<Class<?>> resourceClasses, String type, UriInfo uriInfo)
 		throws Exception {
 
-		return getOpenAPI(null, resourceClasses, type, uriInfo);
+		return _getOpenAPI(null, null, resourceClasses, type, uriInfo);
 	}
 
 	@Activate
@@ -209,14 +137,29 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 		_openAPIContributors.close();
 	}
 
-	private String _getBasePath(UriInfo uriInfo) {
-		String basePath = null;
+	private String _getBasePath(
+		HttpServletRequest httpServletRequest, UriInfo uriInfo) {
 
-		if (uriInfo != null) {
-			basePath = UriInfoUtil.getBasePath(uriInfo);
+		if (uriInfo == null) {
+			return null;
 		}
 
-		return basePath;
+		if (httpServletRequest == null) {
+			return UriInfoUtil.getBasePath(uriInfo);
+		}
+
+		String scheme = Http.HTTP;
+
+		if (_portal.isSecure(httpServletRequest)) {
+			scheme = Http.HTTPS;
+		}
+
+		return UriInfoUtil.getBasePath(
+			_portal.getForwardedHost(httpServletRequest), scheme, uriInfo);
+	}
+
+	private String _getBasePath(UriInfo uriInfo) {
+		return _getBasePath(null, uriInfo);
 	}
 
 	private Set<String> _getDTOClassNames(Set<Class<?>> resourceClasses) {
@@ -339,6 +282,102 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 		}
 
 		return propertyDefinitions;
+	}
+
+	private Response _getOpenAPI(
+			HttpServletRequest httpServletRequest,
+			OpenAPISchemaFilter openAPISchemaFilter,
+			Set<Class<?>> resourceClasses, String type, UriInfo uriInfo)
+		throws Exception {
+
+		JaxrsOpenApiContextBuilder jaxrsOpenApiContextBuilder =
+			new JaxrsOpenApiContextBuilder();
+
+		OpenApiContext openApiContext = jaxrsOpenApiContextBuilder.buildContext(
+			true);
+
+		GenericOpenApiContext genericOpenApiContext =
+			(GenericOpenApiContext)openApiContext;
+
+		genericOpenApiContext.setCacheTTL(0L);
+		genericOpenApiContext.setOpenApiScanner(
+			new OpenApiScanner() {
+
+				@Override
+				public Set<Class<?>> classes() {
+					return resourceClasses;
+				}
+
+				@Override
+				public Map<String, Object> resources() {
+					return new HashMap<>();
+				}
+
+				@Override
+				public void setConfiguration(
+					OpenAPIConfiguration openAPIConfiguration) {
+				}
+
+			});
+
+		OpenAPI openAPI = openApiContext.read();
+
+		OpenAPISchemaFilter mergedOpenAPISchemaFilter =
+			_mergeOpenAPISchemaFilters(
+				openAPISchemaFilter,
+				_getOpenAPISchemaFilter(
+					_getBasePath(uriInfo), _extensionProviderRegistry,
+					resourceClasses));
+
+		if (mergedOpenAPISchemaFilter != null) {
+			SpecFilter specFilter = new SpecFilter();
+
+			Map<String, List<String>> queryParameters = null;
+
+			if (uriInfo != null) {
+				queryParameters = uriInfo.getQueryParameters();
+			}
+
+			openAPI = specFilter.filter(
+				openAPI, _toOpenAPISpecFilter(mergedOpenAPISchemaFilter),
+				queryParameters, null, null);
+		}
+
+		if (openAPI == null) {
+			return Response.status(
+				404
+			).build();
+		}
+
+		if (uriInfo != null) {
+			Server server = new Server();
+
+			server.setUrl(_getBasePath(httpServletRequest, uriInfo));
+
+			openAPI.setServers(Collections.singletonList(server));
+		}
+
+		for (OpenAPIContributor openAPIContributor : _openAPIContributors) {
+			openAPIContributor.contribute(openAPI, uriInfo);
+		}
+
+		if (StringUtil.equalsIgnoreCase("yaml", type)) {
+			return Response.status(
+				Response.Status.OK
+			).entity(
+				Yaml.pretty(openAPI)
+			).type(
+				"application/yaml"
+			).build();
+		}
+
+		return Response.status(
+			Response.Status.OK
+		).entity(
+			openAPI
+		).type(
+			MediaType.APPLICATION_JSON_TYPE
+		).build();
 	}
 
 	private OpenAPISchemaFilter _getOpenAPISchemaFilter(
@@ -905,5 +944,8 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 	private JaxRsResourceRegistry _jaxRsResourceRegistry;
 
 	private ServiceTrackerList<OpenAPIContributor> _openAPIContributors;
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-impl/src/main/java/com/liferay/headless/commerce/punchout/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-impl/src/main/java/com/liferay/headless/commerce/punchout/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -59,19 +61,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -59,19 +61,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -58,19 +60,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -58,19 +60,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -25,6 +25,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -58,19 +60,32 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz =
-				_openAPIResource.getClass();
-
 			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+			return _openAPIResource.getOpenAPI(
+				_httpServletRequest, _resourceClasses, type, _uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return _openAPIResource.getOpenAPI(
+					_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/openapi_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/openapi_resource_impl.ftl
@@ -11,6 +11,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.servlet.http.HttpServletRequest;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -55,17 +57,33 @@ public class OpenAPIResourceImpl {
 	@Path("/openapi.{type:json|yaml}")
 	@Produces({MediaType.APPLICATION_JSON, "application/yaml"})
 	public Response getOpenAPI(@PathParam("type") String type) throws Exception {
+
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
 		try {
-			Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+			clazz.getMethod(
+			"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+			UriInfo.class);
 
-			clazz.getMethod("getOpenAPI", Set.class, String.class, UriInfo.class);
+			return _openAPIResource.getOpenAPI(
+			_httpServletRequest, _resourceClasses, type, _uriInfo);
 		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
-		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				clazz.getMethod(
+				"getOpenAPI", Set.class, String.class, UriInfo.class);
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+				return _openAPIResource.getOpenAPI(
+				_resourceClasses, type, _uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
 	}
+
+	@Context
+	private HttpServletRequest _httpServletRequest;
 
 	@Reference
 	private OpenAPIResource _openAPIResource;


### PR DESCRIPTION
- LPS-137769 headless-discovery-impl - enable API explorer to work behind reverse proxy
- LPS-137769 portal-tool-rest-builder - update rest builder to use new method, we need HttpServletRequest to fetch headers to know if Liferay instance is behind reverse proxy
- LPS-137769 portal-vulcan - if X-Forwarded host and port are present, use them when building server URL for API explorer
- LPS-137769 /apps - buildREST
- LPS-137769 /dxp/apps - buildREST
- LPS-137769 analytics-dxp-entity-rest-impl - update build.radle
- LPS-137769 This simplification worked locally, what do you think?
- LPS-137769 portal-vulcan - baseline
