### PR TITLE
COMMERCE-11747 Headless BigDecimal array support

### DIFF
--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_base_json_parser.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_base_json_parser.ftl
@@ -1,5 +1,7 @@
 package ${configYAML.apiPackagePath}.client.json;
 
+import java.math.BigDecimal;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -177,6 +179,16 @@ public abstract class BaseJSONParser<T> {
 	protected abstract T[] createDTOArray(int size);
 
 	protected abstract void setField(T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
 
 	protected Date toDate(String string) {
 		try {

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_serdes.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_serdes.ftl
@@ -261,6 +261,8 @@ public class ${schemaName}SerDes {
 
 						<#if stringUtil.equals(propertyType, "BigDecimal")>
 							${schemaVarName}.set${capitalizedPropertyName}(new BigDecimal((String)jsonParserFieldValue));
+						<#elseif stringUtil.equals(propertyType, "BigDecimal[]")>
+							${schemaVarName}.set${capitalizedPropertyName}(toBigDecimals((Object[])jsonParserFieldValue));
 						<#elseif stringUtil.equals(propertyType, "Date")>
 							${schemaVarName}.set${capitalizedPropertyName}(toDate((String)jsonParserFieldValue));
 						<#elseif stringUtil.equals(propertyType, "Date[]")>


### PR DESCRIPTION
Add support to BigDecimal Array on *SerDes.java generated file.

This PR adds a new method (toBigDecimals) on BaseJSONParser file and use it on *SerDes when managing fieldValues with type BigDecimal[]