### PR TITLE
Graphql bug

### DIFF
--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-api/bnd.bnd
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-api/bnd.bnd
@@ -1,0 +1,6 @@
+Bundle-Name: Liferay Graphql Bug REST API
+Bundle-SymbolicName: com.liferay.graphql.bug.rest.api
+Bundle-Version: 1.0.0
+Export-Package:\
+	com.liferay.graphql.bug.rest.dto.v1_0,\
+	com.liferay.graphql.bug.rest.resource.v1_0

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-api/build.gradle
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-api/build.gradle
@@ -1,0 +1,16 @@
+dependencies {
+	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.16.1"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
+	compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3.2"
+	compileOnly group: "javax.validation", name: "validation-api", version: "2.0.1.Final"
+	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
+	compileOnly group: "javax.xml.bind", name: "jaxb-api", version: "2.3.0"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
+	compileOnly project(":apps:portal-odata:portal-odata-api")
+	compileOnly project(":apps:portal-search:portal-search-api")
+	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
+	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-string")
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-api/src/main/java/com/liferay/graphql/bug/rest/dto/v1_0/Message.java
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-api/src/main/java/com/liferay/graphql/bug/rest/dto/v1_0/Message.java
@@ -1,0 +1,344 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.graphql.bug.rest.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import javax.annotation.Generated;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+@GraphQLName("Message")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "Message")
+public class Message implements Serializable {
+
+	public static Message toDTO(String json) {
+		return ObjectMapperUtil.readValue(Message.class, json);
+	}
+
+	public static Message unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(Message.class, json);
+	}
+
+	@Schema
+	public String getKey() {
+		if (_keySupplier != null) {
+			key = _keySupplier.get();
+
+			_keySupplier = null;
+		}
+
+		return key;
+	}
+
+	public void setKey(String key) {
+		this.key = key;
+
+		_keySupplier = null;
+	}
+
+	@JsonIgnore
+	public void setKey(UnsafeSupplier<String, Exception> keyUnsafeSupplier) {
+		_keySupplier = () -> {
+			try {
+				return keyUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String key;
+
+	@JsonIgnore
+	private Supplier<String> _keySupplier;
+
+	@Schema
+	public String getLanguageId() {
+		if (_languageIdSupplier != null) {
+			languageId = _languageIdSupplier.get();
+
+			_languageIdSupplier = null;
+		}
+
+		return languageId;
+	}
+
+	public void setLanguageId(String languageId) {
+		this.languageId = languageId;
+
+		_languageIdSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setLanguageId(
+		UnsafeSupplier<String, Exception> languageIdUnsafeSupplier) {
+
+		_languageIdSupplier = () -> {
+			try {
+				return languageIdUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String languageId;
+
+	@JsonIgnore
+	private Supplier<String> _languageIdSupplier;
+
+	@Schema
+	public String getValue() {
+		if (_valueSupplier != null) {
+			value = _valueSupplier.get();
+
+			_valueSupplier = null;
+		}
+
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+
+		_valueSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setValue(
+		UnsafeSupplier<String, Exception> valueUnsafeSupplier) {
+
+		_valueSupplier = () -> {
+			try {
+				return valueUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String value;
+
+	@JsonIgnore
+	private Supplier<String> _valueSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Message)) {
+			return false;
+		}
+
+		Message message = (Message)object;
+
+		return Objects.equals(toString(), message.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		String key = getKey();
+
+		if (key != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"key\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(key));
+
+			sb.append("\"");
+		}
+
+		String languageId = getLanguageId();
+
+		if (languageId != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"languageId\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(languageId));
+
+			sb.append("\"");
+		}
+
+		String value = getValue();
+
+		if (value != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"value\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(value));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@Schema(
+		accessMode = Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.graphql.bug.rest.dto.v1_0.Message",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-api/src/main/java/com/liferay/graphql/bug/rest/resource/v1_0/MessageResource.java
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-api/src/main/java/com/liferay/graphql/bug/rest/resource/v1_0/MessageResource.java
@@ -1,0 +1,147 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.graphql.bug.rest.resource.v1_0;
+
+import com.liferay.graphql.bug.rest.dto.v1_0.Message;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.pagination.Page;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * To access this resource, run:
+ *
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/headless-bug/v1.0
+ *
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+@ProviderType
+public interface MessageResource {
+
+	public Page<Message> getMessagesPage(String[] keys) throws Exception;
+
+	public Response postMessagesPageExportBatch(
+			String[] keys, String callbackURL, String contentType,
+			String fieldNames)
+		throws Exception;
+
+	public default void setContextAcceptLanguage(
+		AcceptLanguage contextAcceptLanguage) {
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser);
+
+	public void setExpressionConvert(
+		ExpressionConvert<Filter> expressionConvert);
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider);
+
+	public void setGroupLocalService(GroupLocalService groupLocalService);
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService);
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService);
+
+	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider);
+
+	public void setVulcanBatchEngineExportTaskResource(
+		VulcanBatchEngineExportTaskResource
+			vulcanBatchEngineExportTaskResource);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
+
+	public default Filter toFilter(String filterString) {
+		return toFilter(
+			filterString, Collections.<String, List<String>>emptyMap());
+	}
+
+	public default Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		return null;
+	}
+
+	public default Sort[] toSorts(String sortsString) {
+		return new Sort[0];
+	}
+
+	@ProviderType
+	public interface Builder {
+
+		public MessageResource build();
+
+		public Builder checkPermissions(boolean checkPermissions);
+
+		public Builder httpServletRequest(
+			HttpServletRequest httpServletRequest);
+
+		public Builder httpServletResponse(
+			HttpServletResponse httpServletResponse);
+
+		public Builder preferredLocale(Locale preferredLocale);
+
+		public Builder uriInfo(UriInfo uriInfo);
+
+		public Builder user(com.liferay.portal.kernel.model.User user);
+
+	}
+
+	@ProviderType
+	public interface Factory {
+
+		public Builder create();
+
+	}
+
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/bnd.bnd
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Graphql Bug REST Client
+Bundle-SymbolicName: com.liferay.graphql.bug.rest.client
+Bundle-Version: 1.0.0

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/build.gradle
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3.2"
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/src/main/java/com/liferay/graphql/bug/rest/client/aggregation/Aggregation.java
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/src/main/java/com/liferay/graphql/bug/rest/client/aggregation/Aggregation.java
@@ -1,0 +1,30 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.graphql.bug.rest.client.aggregation;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+public class Aggregation {
+
+	public Map<String, String> getAggregationTerms() {
+		return _aggregationTerms;
+	}
+
+	public void setAggregationTerms(Map<String, String> aggregationTerms) {
+		_aggregationTerms = aggregationTerms;
+	}
+
+	private Map<String, String> _aggregationTerms = new HashMap<>();
+
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/src/main/java/com/liferay/graphql/bug/rest/client/aggregation/Facet.java
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/src/main/java/com/liferay/graphql/bug/rest/client/aggregation/Facet.java
@@ -1,0 +1,70 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.graphql.bug.rest.client.aggregation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+public class Facet {
+
+	public Facet() {
+	}
+
+	public Facet(String facetCriteria, List<FacetValue> facetValues) {
+		_facetCriteria = facetCriteria;
+		_facetValues = facetValues;
+	}
+
+	public String getFacetCriteria() {
+		return _facetCriteria;
+	}
+
+	public List<FacetValue> getFacetValues() {
+		return _facetValues;
+	}
+
+	public void setFacetCriteria(String facetCriteria) {
+		_facetCriteria = facetCriteria;
+	}
+
+	public void setFacetValues(List<FacetValue> facetValues) {
+		_facetValues = facetValues;
+	}
+
+	public static class FacetValue {
+
+		public FacetValue() {
+		}
+
+		public FacetValue(Integer numberOfOccurrences, String term) {
+			_numberOfOccurrences = numberOfOccurrences;
+			_term = term;
+		}
+
+		public Integer getNumberOfOccurrences() {
+			return _numberOfOccurrences;
+		}
+
+		public String getTerm() {
+			return _term;
+		}
+
+		private Integer _numberOfOccurrences;
+		private String _term;
+
+	}
+
+	private String _facetCriteria;
+	private List<FacetValue> _facetValues = new ArrayList<>();
+
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/src/main/java/com/liferay/graphql/bug/rest/client/dto/v1_0/Message.java
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/src/main/java/com/liferay/graphql/bug/rest/client/dto/v1_0/Message.java
@@ -1,0 +1,120 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.graphql.bug.rest.client.dto.v1_0;
+
+import com.liferay.graphql.bug.rest.client.function.UnsafeSupplier;
+import com.liferay.graphql.bug.rest.client.serdes.v1_0.MessageSerDes;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+public class Message implements Cloneable, Serializable {
+
+	public static Message toDTO(String json) {
+		return MessageSerDes.toDTO(json);
+	}
+
+	public String getKey() {
+		return key;
+	}
+
+	public void setKey(String key) {
+		this.key = key;
+	}
+
+	public void setKey(UnsafeSupplier<String, Exception> keyUnsafeSupplier) {
+		try {
+			key = keyUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String key;
+
+	public String getLanguageId() {
+		return languageId;
+	}
+
+	public void setLanguageId(String languageId) {
+		this.languageId = languageId;
+	}
+
+	public void setLanguageId(
+		UnsafeSupplier<String, Exception> languageIdUnsafeSupplier) {
+
+		try {
+			languageId = languageIdUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String languageId;
+
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+	public void setValue(
+		UnsafeSupplier<String, Exception> valueUnsafeSupplier) {
+
+		try {
+			value = valueUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String value;
+
+	@Override
+	public Message clone() throws CloneNotSupportedException {
+		return (Message)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Message)) {
+			return false;
+		}
+
+		Message message = (Message)object;
+
+		return Objects.equals(toString(), message.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return MessageSerDes.toJSON(this);
+	}
+
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/src/main/java/com/liferay/graphql/bug/rest/client/function/UnsafeSupplier.java
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/src/main/java/com/liferay/graphql/bug/rest/client/function/UnsafeSupplier.java
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.graphql.bug.rest.client.function;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@FunctionalInterface
+@Generated("")
+public interface UnsafeSupplier<T, E extends Throwable> {
+
+	public T get() throws E;
+
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/src/main/java/com/liferay/graphql/bug/rest/client/http/HttpInvoker.java
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/src/main/java/com/liferay/graphql/bug/rest/client/http/HttpInvoker.java
@@ -1,0 +1,461 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.graphql.bug.rest.client.http;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+
+import java.lang.reflect.Field;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLEncoder;
+
+import java.util.Base64;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+public class HttpInvoker {
+
+	public static HttpInvoker newHttpInvoker() {
+		return new HttpInvoker();
+	}
+
+	public HttpInvoker body(String body, String contentType) {
+		_body = body;
+		_contentType = contentType;
+
+		return this;
+	}
+
+	public HttpInvoker header(String name, String value) {
+		_headers.put(name, value);
+
+		return this;
+	}
+
+	public HttpInvoker httpMethod(HttpMethod httpMethod) {
+		_httpMethod = httpMethod;
+
+		return this;
+	}
+
+	public HttpResponse invoke() throws IOException {
+		HttpResponse httpResponse = new HttpResponse();
+
+		HttpURLConnection httpURLConnection = _openHttpURLConnection();
+
+		byte[] binaryContent = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(binaryContent);
+		httpResponse.setContent(new String(binaryContent));
+
+		httpResponse.setContentType(
+			httpURLConnection.getHeaderField("Content-Type"));
+		httpResponse.setMessage(httpURLConnection.getResponseMessage());
+		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
+
+		httpURLConnection.disconnect();
+
+		return httpResponse;
+	}
+
+	public HttpInvoker multipart() {
+		_contentType =
+			"multipart/form-data; charset=utf-8; boundary=__MULTIPART_BOUNDARY__";
+		_multipartBoundary = "__MULTIPART_BOUNDARY__";
+
+		return this;
+	}
+
+	public HttpInvoker parameter(String name, String value) {
+		return parameter(name, new String[] {value});
+	}
+
+	public HttpInvoker parameter(String name, String[] values) {
+		String[] oldValues = _parameters.get(name);
+
+		if (oldValues != null) {
+			String[] newValues = new String[oldValues.length + values.length];
+
+			System.arraycopy(oldValues, 0, newValues, 0, oldValues.length);
+			System.arraycopy(
+				values, 0, newValues, oldValues.length, values.length);
+
+			_parameters.put(name, newValues);
+		}
+		else {
+			_parameters.put(name, values);
+		}
+
+		return this;
+	}
+
+	public HttpInvoker part(String name, File file) {
+		_files.put(name, file);
+
+		return this;
+	}
+
+	public HttpInvoker part(String name, String value) {
+		_parts.put(name, value);
+
+		return this;
+	}
+
+	public HttpInvoker path(String path) {
+		_path = path;
+
+		return this;
+	}
+
+	public HttpInvoker path(String name, Object value) {
+		_path = _path.replaceFirst("\\{" + name + "\\}", String.valueOf(value));
+
+		return this;
+	}
+
+	public HttpInvoker userNameAndPassword(String userNameAndPassword)
+		throws IOException {
+
+		Base64.Encoder encoder = Base64.getEncoder();
+
+		_encodedUserNameAndPassword = new String(
+			encoder.encode(userNameAndPassword.getBytes("UTF-8")), "UTF-8");
+
+		return this;
+	}
+
+	public enum HttpMethod {
+
+		DELETE, GET, PATCH, POST, PUT
+
+	}
+
+	public class HttpResponse {
+
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
+		public String getContent() {
+			return _content;
+		}
+
+		public String getContentType() {
+			return _contentType;
+		}
+
+		public String getMessage() {
+			return _message;
+		}
+
+		public int getStatusCode() {
+			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
+		}
+
+		public void setContent(String content) {
+			_content = content;
+		}
+
+		public void setContentType(String contentType) {
+			_contentType = contentType;
+		}
+
+		public void setMessage(String message) {
+			_message = message;
+		}
+
+		public void setStatusCode(int statusCode) {
+			_statusCode = statusCode;
+		}
+
+		private byte[] _binaryContent;
+		private String _content;
+		private String _contentType;
+		private String _message;
+		private int _statusCode;
+
+	}
+
+	private HttpInvoker() {
+	}
+
+	private void _appendPart(
+			OutputStream outputStream, PrintWriter printWriter, String key,
+			Object value)
+		throws IOException {
+
+		printWriter.append("\r\n--");
+		printWriter.append(_multipartBoundary);
+		printWriter.append("\r\nContent-Disposition: form-data; name=\"");
+		printWriter.append(key);
+		printWriter.append("\";");
+
+		if (value instanceof File) {
+			File file = (File)value;
+
+			printWriter.append(" filename=\"");
+			printWriter.append(_filter(file.getName()));
+			printWriter.append("\"\r\nContent-Type: ");
+			printWriter.append(
+				URLConnection.guessContentTypeFromName(file.getName()));
+			printWriter.append("\r\n\r\n");
+
+			printWriter.flush();
+
+			byte[] buffer = new byte[4096];
+			FileInputStream fileInputStream = new FileInputStream(file);
+			int read = -1;
+
+			while ((read = fileInputStream.read(buffer)) != -1) {
+				outputStream.write(buffer, 0, read);
+			}
+
+			outputStream.flush();
+
+			fileInputStream.close();
+		}
+		else {
+			printWriter.append("\r\n\r\n");
+			printWriter.append(value.toString());
+		}
+
+		printWriter.append("\r\n");
+	}
+
+	private String _filter(String fileName) {
+		fileName = fileName.replaceAll("\"", "");
+		fileName = fileName.replaceAll("\n", "");
+		fileName = fileName.replaceAll("\r", "");
+
+		return fileName;
+	}
+
+	private HttpURLConnection _getHttpURLConnection(
+			HttpMethod httpMethod, String urlString)
+		throws IOException {
+
+		URL url = new URL(urlString);
+
+		HttpURLConnection httpURLConnection =
+			(HttpURLConnection)url.openConnection();
+
+		try {
+			HttpURLConnection methodHttpURLConnection = httpURLConnection;
+
+			if (Objects.equals(url.getProtocol(), "https")) {
+				Class<?> clazz = httpURLConnection.getClass();
+
+				Field field = clazz.getDeclaredField("delegate");
+
+				field.setAccessible(true);
+
+				methodHttpURLConnection = (HttpURLConnection)field.get(
+					httpURLConnection);
+			}
+
+			_methodField.set(methodHttpURLConnection, httpMethod.name());
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new IOException(reflectiveOperationException);
+		}
+
+		return httpURLConnection;
+	}
+
+	private String _getQueryString() throws IOException {
+		StringBuilder sb = new StringBuilder();
+
+		Set<Map.Entry<String, String[]>> set = _parameters.entrySet();
+
+		Iterator<Map.Entry<String, String[]>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, String[]> entry = iterator.next();
+
+			String[] values = entry.getValue();
+
+			for (int i = 0; i < values.length; i++) {
+				String name = URLEncoder.encode(entry.getKey(), "UTF-8");
+
+				sb.append(name);
+
+				sb.append("=");
+
+				String value = URLEncoder.encode(values[i], "UTF-8");
+
+				sb.append(value);
+
+				if ((i + 1) < values.length) {
+					sb.append("&");
+				}
+			}
+
+			if (iterator.hasNext()) {
+				sb.append("&");
+			}
+		}
+
+		return sb.toString();
+	}
+
+	private HttpURLConnection _openHttpURLConnection() throws IOException {
+		String urlString = _path;
+
+		String queryString = _getQueryString();
+
+		if (queryString.length() > 0) {
+			if (!urlString.contains("?")) {
+				urlString += "?";
+			}
+
+			urlString += queryString;
+		}
+
+		HttpURLConnection httpURLConnection = _getHttpURLConnection(
+			_httpMethod, urlString);
+
+		if (_encodedUserNameAndPassword != null) {
+			httpURLConnection.setRequestProperty(
+				"Authorization", "Basic " + _encodedUserNameAndPassword);
+		}
+
+		if (_contentType != null) {
+			httpURLConnection.setRequestProperty("Content-Type", _contentType);
+		}
+
+		for (Map.Entry<String, String> header : _headers.entrySet()) {
+			httpURLConnection.setRequestProperty(
+				header.getKey(), header.getValue());
+		}
+
+		_writeBody(httpURLConnection);
+
+		return httpURLConnection;
+	}
+
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
+		throws IOException {
+
+		ByteArrayOutputStream byteArrayOutputStream =
+			new ByteArrayOutputStream();
+
+		InputStream inputStream = null;
+
+		int responseCode = httpURLConnection.getResponseCode();
+
+		if (responseCode > 299) {
+			inputStream = httpURLConnection.getErrorStream();
+		}
+		else {
+			inputStream = httpURLConnection.getInputStream();
+		}
+
+		byte[] bytes = new byte[8192];
+
+		while (true) {
+			int read = inputStream.read(bytes, 0, bytes.length);
+
+			if (read == -1) {
+				break;
+			}
+
+			byteArrayOutputStream.write(bytes, 0, read);
+		}
+
+		byteArrayOutputStream.flush();
+
+		return byteArrayOutputStream.toByteArray();
+	}
+
+	private void _writeBody(HttpURLConnection httpURLConnection)
+		throws IOException {
+
+		if ((_body == null) && _files.isEmpty() && _parts.isEmpty()) {
+			return;
+		}
+
+		httpURLConnection.setDoOutput(true);
+
+		OutputStream outputStream = httpURLConnection.getOutputStream();
+
+		try (PrintWriter printWriter = new PrintWriter(
+				new OutputStreamWriter(outputStream, "UTF-8"), true)) {
+
+			if (_contentType.startsWith("multipart/form-data")) {
+				for (Map.Entry<String, String> entry : _parts.entrySet()) {
+					_appendPart(
+						outputStream, printWriter, entry.getKey(),
+						entry.getValue());
+				}
+
+				for (Map.Entry<String, File> entry : _files.entrySet()) {
+					_appendPart(
+						outputStream, printWriter, entry.getKey(),
+						entry.getValue());
+				}
+
+				printWriter.append("--" + _multipartBoundary + "--");
+
+				printWriter.flush();
+
+				outputStream.flush();
+			}
+			else {
+				printWriter.append(_body);
+
+				printWriter.flush();
+			}
+		}
+	}
+
+	private static final Field _methodField;
+
+	static {
+		try {
+			_methodField = HttpURLConnection.class.getDeclaredField("method");
+
+			_methodField.setAccessible(true);
+		}
+		catch (Exception exception) {
+			throw new ExceptionInInitializerError(exception);
+		}
+	}
+
+	private String _body;
+	private String _contentType;
+	private String _encodedUserNameAndPassword;
+	private final Map<String, File> _files = new LinkedHashMap<>();
+	private final Map<String, String> _headers = new LinkedHashMap<>();
+	private HttpMethod _httpMethod = HttpMethod.GET;
+	private String _multipartBoundary;
+	private final Map<String, String[]> _parameters = new LinkedHashMap<>();
+	private final Map<String, String> _parts = new LinkedHashMap<>();
+	private String _path;
+
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/src/main/java/com/liferay/graphql/bug/rest/client/json/BaseJSONParser.java
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/src/main/java/com/liferay/graphql/bug/rest/client/json/BaseJSONParser.java
@@ -1,0 +1,648 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.graphql.bug.rest.client.json;
+
+import java.math.BigDecimal;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+import java.util.TreeMap;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+public abstract class BaseJSONParser<T> {
+
+	public static final String[][] JSON_ESCAPE_STRINGS = new String[][] {
+		{"\\", "\\\\"}, {"\"", "\\\""}, {"\b", "\\b"}, {"\f", "\\f"},
+		{"\n", "\\n"}, {"\r", "\\r"}, {"\t", "\\t"}
+	};
+
+	public T parseToDTO(String json) {
+		if (json == null) {
+			throw new IllegalArgumentException("JSON is null");
+		}
+
+		_init(json);
+
+		_assertStartsWithAndEndsWith("{", "}");
+
+		T dto = createDTO();
+
+		if (_isEmpty()) {
+			return dto;
+		}
+
+		_readNextChar();
+
+		_readWhileLastCharIsWhiteSpace();
+
+		_readNextChar();
+
+		if (_isLastChar('}')) {
+			_readWhileLastCharIsWhiteSpace();
+
+			if (!_isEndOfJSON()) {
+				_readNextChar();
+
+				throw new IllegalArgumentException(
+					"Expected end of JSON, but found '" + _lastChar + "'");
+			}
+
+			return dto;
+		}
+
+		do {
+			_readWhileLastCharIsWhiteSpace();
+
+			String fieldName = _readValueAsString();
+
+			_readWhileLastCharIsWhiteSpace();
+
+			_assertLastChar(':');
+
+			_readNextChar();
+
+			_readWhileLastCharIsWhiteSpace();
+
+			setField(dto, fieldName, _readValue(parseMaps(fieldName)));
+
+			_readWhileLastCharIsWhiteSpace();
+		}
+		while (_ifLastCharMatchesThenRead(','));
+
+		return dto;
+	}
+
+	public T[] parseToDTOs(String json) {
+		if (json == null) {
+			throw new IllegalArgumentException("JSON is null");
+		}
+
+		_init(json);
+
+		_assertStartsWithAndEndsWith("[", "]");
+
+		if (_isEmpty()) {
+			return createDTOArray(0);
+		}
+
+		_readNextChar();
+
+		_readWhileLastCharIsWhiteSpace();
+
+		if (_isLastChar(']')) {
+			_readNextChar();
+
+			return createDTOArray(0);
+		}
+
+		_readWhileLastCharIsWhiteSpace();
+
+		Object[] objects = (Object[])_readValue();
+
+		T[] dtos = createDTOArray(objects.length);
+
+		for (int i = 0; i < dtos.length; i++) {
+			dtos[i] = parseToDTO((String)objects[i]);
+		}
+
+		return dtos;
+	}
+
+	public Map<String, Object> parseToMap(String json) {
+		if (json == null) {
+			throw new IllegalArgumentException("JSON is null");
+		}
+
+		_init(json);
+
+		_assertStartsWithAndEndsWith("{", "}");
+
+		Map<String, Object> map = new TreeMap<>();
+
+		_setCaptureStart();
+
+		_readNextChar();
+
+		_readNextChar();
+
+		_readWhileLastCharIsWhiteSpace();
+
+		if (_isLastChar('}')) {
+			return map;
+		}
+
+		do {
+			_readWhileLastCharIsWhiteSpace();
+
+			String key = _readValueAsString();
+
+			_readWhileLastCharIsWhiteSpace();
+
+			if (!_ifLastCharMatchesThenRead(':')) {
+				throw new IllegalArgumentException("Expected ':'");
+			}
+
+			_readWhileLastCharIsWhiteSpace();
+
+			map.put(key, _readValue(true));
+
+			_readWhileLastCharIsWhiteSpace();
+		}
+		while (_ifLastCharMatchesThenRead(','));
+
+		_readWhileLastCharIsWhiteSpace();
+
+		if (!_ifLastCharMatchesThenRead('}')) {
+			throw new IllegalArgumentException(
+				"Expected either ',' or '}', but found '" + _lastChar + "'");
+		}
+
+		return map;
+	}
+
+	protected abstract T createDTO();
+
+	protected abstract T[] createDTOArray(int size);
+
+	protected abstract boolean parseMaps(String jsonParserFieldName);
+
+	protected abstract void setField(
+		T dto, String jsonParserFieldName, Object jsonParserFieldValue);
+
+	protected BigDecimal[] toBigDecimals(Object[] objects) {
+		BigDecimal[] bigdecimals = new BigDecimal[objects.length];
+
+		for (int i = 0; i < bigdecimals.length; i++) {
+			bigdecimals[i] = new BigDecimal(objects[i].toString());
+		}
+
+		return bigdecimals;
+	}
+
+	protected Date toDate(String string) {
+		try {
+			return _dateFormat.parse(string);
+		}
+		catch (ParseException pe) {
+			throw new IllegalArgumentException(
+				"Unable to parse date from " + string, pe);
+		}
+	}
+
+	protected Date[] toDates(Object[] objects) {
+		Date[] dates = new Date[objects.length];
+
+		for (int i = 0; i < dates.length; i++) {
+			dates[i] = toDate((String)objects[i]);
+		}
+
+		return dates;
+	}
+
+	protected Integer[] toIntegers(Object[] objects) {
+		Integer[] integers = new Integer[objects.length];
+
+		for (int i = 0; i < integers.length; i++) {
+			integers[i] = Integer.valueOf(objects[i].toString());
+		}
+
+		return integers;
+	}
+
+	protected Long[] toLongs(Object[] objects) {
+		Long[] longs = new Long[objects.length];
+
+		for (int i = 0; i < longs.length; i++) {
+			longs[i] = Long.valueOf(objects[i].toString());
+		}
+
+		return longs;
+	}
+
+	protected String toString(Date date) {
+		return _dateFormat.format(date);
+	}
+
+	protected String[] toStrings(Object[] objects) {
+		String[] strings = new String[objects.length];
+
+		for (int i = 0; i < strings.length; i++) {
+			strings[i] = (String)objects[i];
+		}
+
+		return strings;
+	}
+
+	private void _assertLastChar(char c) {
+		if (_lastChar != c) {
+			throw new IllegalArgumentException(
+				String.format(
+					"Expected last char '%s', but found '%s'", c, _lastChar));
+		}
+	}
+
+	private void _assertStartsWithAndEndsWith(String prefix, String sufix) {
+		if (!_json.startsWith(prefix)) {
+			throw new IllegalArgumentException(
+				String.format(
+					"Expected starts with '%s', but found '%s' in '%s'", prefix,
+					_json.charAt(0), _json));
+		}
+
+		if (!_json.endsWith(sufix)) {
+			throw new IllegalArgumentException(
+				String.format(
+					"Expected ends with '%s', but found '%s' in '%s'", sufix,
+					_json.charAt(_json.length() - 1), _json));
+		}
+	}
+
+	private String _getCapturedJSONSubstring() {
+		return _json.substring(_captureStartStack.pop(), _index - 1);
+	}
+
+	private String _getCapturedSubstring() {
+		return _unescape(_getCapturedJSONSubstring());
+	}
+
+	private boolean _ifLastCharMatchesThenRead(char ch) {
+		if (_lastChar != ch) {
+			return false;
+		}
+
+		_readNextChar();
+
+		return true;
+	}
+
+	private void _init(String json) {
+		_captureStartStack = new Stack<>();
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
+		_index = 0;
+		_json = json.trim();
+		_lastChar = 0;
+	}
+
+	private boolean _isCharEscaped(String string, int index) {
+		int backslashCount = 0;
+
+		while (((index - 1 - backslashCount) >= 0) &&
+			   (string.charAt(index - 1 - backslashCount) == '\\')) {
+
+			backslashCount++;
+		}
+
+		if ((backslashCount % 2) == 0) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private boolean _isEmpty() {
+		String substring = _json.substring(1, _json.length() - 1);
+
+		substring = substring.trim();
+
+		return substring.isEmpty();
+	}
+
+	private boolean _isEndOfJSON() {
+		if (_index == _json.length()) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isLastChar(char c) {
+		if (_lastChar == c) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isLastCharDecimalSeparator() {
+		if (_lastChar == '.') {
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isLastCharDigit() {
+		if ((_lastChar >= '0') && (_lastChar <= '9')) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isLastCharNegative() {
+		if (_lastChar == '-') {
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isLastCharPositive() {
+		if (_lastChar == '+') {
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isLastCharScientificNotation() {
+		if (_lastChar == 'E') {
+			return true;
+		}
+
+		return false;
+	}
+
+	private void _readNextChar() {
+		if (!_isEndOfJSON()) {
+			_lastChar = _json.charAt(_index++);
+		}
+	}
+
+	private Object _readValue() {
+		return _readValue(false);
+	}
+
+	private Object _readValue(boolean parseMaps) {
+		if (_lastChar == '[') {
+			return _readValueAsArray(parseMaps);
+		}
+		else if (_lastChar == 'f') {
+			return _readValueAsBooleanFalse();
+		}
+		else if (_lastChar == 't') {
+			return _readValueAsBooleanTrue();
+		}
+		else if (_lastChar == 'n') {
+			return _readValueAsObjectNull();
+		}
+		else if (_lastChar == '"') {
+			return _readValueAsString();
+		}
+		else if (parseMaps && (_lastChar == '{')) {
+			try {
+				Class<? extends BaseJSONParser> clazz = getClass();
+
+				BaseJSONParser baseJSONParser = clazz.newInstance();
+
+				return baseJSONParser.parseToMap(_readValueAsStringJSON());
+			}
+			catch (Exception e) {
+				throw new IllegalArgumentException(
+					"Expected JSON object or map");
+			}
+		}
+		else if (_lastChar == '{') {
+			return _readValueAsStringJSON();
+		}
+		else if ((_lastChar == '-') || (_lastChar == '0') ||
+				 (_lastChar == '1') || (_lastChar == '2') ||
+				 (_lastChar == '3') || (_lastChar == '4') ||
+				 (_lastChar == '5') || (_lastChar == '6') ||
+				 (_lastChar == '7') || (_lastChar == '8') ||
+				 (_lastChar == '9')) {
+
+			return _readValueAsStringNumber();
+		}
+		else {
+			throw new IllegalArgumentException();
+		}
+	}
+
+	private Object[] _readValueAsArray(boolean parseMaps) {
+		List<Object> objects = new ArrayList<>();
+
+		_readNextChar();
+
+		_readWhileLastCharIsWhiteSpace();
+
+		if (_isLastChar(']')) {
+			_readNextChar();
+
+			return objects.toArray();
+		}
+
+		do {
+			_readWhileLastCharIsWhiteSpace();
+
+			objects.add(_readValue(parseMaps));
+
+			_readWhileLastCharIsWhiteSpace();
+		}
+		while (_ifLastCharMatchesThenRead(','));
+
+		if (!_isLastChar(']')) {
+			throw new IllegalArgumentException(
+				"Expected ']', but found '" + _lastChar + "'");
+		}
+
+		_readNextChar();
+
+		return objects.toArray();
+	}
+
+	private boolean _readValueAsBooleanFalse() {
+		_readNextChar();
+
+		_assertLastChar('a');
+
+		_readNextChar();
+
+		_assertLastChar('l');
+
+		_readNextChar();
+
+		_assertLastChar('s');
+
+		_readNextChar();
+
+		_assertLastChar('e');
+
+		_readNextChar();
+
+		return false;
+	}
+
+	private boolean _readValueAsBooleanTrue() {
+		_readNextChar();
+
+		_assertLastChar('r');
+
+		_readNextChar();
+
+		_assertLastChar('u');
+
+		_readNextChar();
+
+		_assertLastChar('e');
+
+		_readNextChar();
+
+		return true;
+	}
+
+	private Object _readValueAsObjectNull() {
+		_readNextChar();
+
+		_assertLastChar('u');
+
+		_readNextChar();
+
+		_assertLastChar('l');
+
+		_readNextChar();
+
+		_assertLastChar('l');
+
+		_readNextChar();
+
+		return null;
+	}
+
+	private String _readValueAsString() {
+		_readNextChar();
+
+		_setCaptureStart();
+
+		while ((_lastChar != '"') || _isCharEscaped(_json, _index - 1)) {
+			_readNextChar();
+		}
+
+		String string = _getCapturedSubstring();
+
+		_readNextChar();
+
+		return string;
+	}
+
+	private String _readValueAsStringJSON() {
+		_setCaptureStart();
+
+		_readNextChar();
+
+		if (_isLastChar('}')) {
+			_readNextChar();
+
+			return _getCapturedJSONSubstring();
+		}
+
+		_readWhileLastCharIsWhiteSpace();
+
+		if (_isLastChar('}')) {
+			_readNextChar();
+
+			return _getCapturedJSONSubstring();
+		}
+
+		do {
+			_readWhileLastCharIsWhiteSpace();
+
+			_readValueAsString();
+
+			_readWhileLastCharIsWhiteSpace();
+
+			if (!_ifLastCharMatchesThenRead(':')) {
+				throw new IllegalArgumentException("Expected ':'");
+			}
+
+			_readWhileLastCharIsWhiteSpace();
+
+			_readValue();
+
+			_readWhileLastCharIsWhiteSpace();
+		}
+		while (_ifLastCharMatchesThenRead(','));
+
+		_readWhileLastCharIsWhiteSpace();
+
+		if (!_ifLastCharMatchesThenRead('}')) {
+			throw new IllegalArgumentException(
+				"Expected either ',' or '}', but found '" + _lastChar + "'");
+		}
+
+		return _getCapturedJSONSubstring();
+	}
+
+	private String _readValueAsStringNumber() {
+		_setCaptureStart();
+
+		do {
+			_readNextChar();
+		}
+		while (_isLastCharDigit() || _isLastCharDecimalSeparator() ||
+			   _isLastCharNegative() || _isLastCharPositive() ||
+			   _isLastCharScientificNotation());
+
+		return _getCapturedSubstring();
+	}
+
+	private void _readWhileLastCharIsWhiteSpace() {
+		while ((_lastChar == ' ') || (_lastChar == '\n') ||
+			   (_lastChar == '\r') || (_lastChar == '\t')) {
+
+			_readNextChar();
+		}
+	}
+
+	private void _setCaptureStart() {
+		_captureStartStack.push(_index - 1);
+	}
+
+	private String _unescape(String string) {
+		for (int i = JSON_ESCAPE_STRINGS.length - 1; i >= 0; i--) {
+			String[] escapeStrings = JSON_ESCAPE_STRINGS[i];
+
+			int index = string.indexOf(escapeStrings[1]);
+
+			while (index != -1) {
+				if (!_isCharEscaped(string, index)) {
+					string =
+						string.substring(0, index) + escapeStrings[0] +
+							string.substring(index + escapeStrings[1].length());
+
+					index = string.indexOf(
+						escapeStrings[1], index + escapeStrings[0].length());
+				}
+				else {
+					index = string.indexOf(
+						escapeStrings[1], index + escapeStrings[1].length());
+				}
+			}
+		}
+
+		return string;
+	}
+
+	private Stack<Integer> _captureStartStack;
+	private DateFormat _dateFormat;
+	private int _index;
+	private String _json;
+	private char _lastChar;
+
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/src/main/java/com/liferay/graphql/bug/rest/client/pagination/Page.java
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/src/main/java/com/liferay/graphql/bug/rest/client/pagination/Page.java
@@ -1,0 +1,326 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.graphql.bug.rest.client.pagination;
+
+import com.liferay.graphql.bug.rest.client.aggregation.Facet;
+import com.liferay.graphql.bug.rest.client.json.BaseJSONParser;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+public class Page<T> {
+
+	public static <T> Page<T> of(
+		String json, Function<String, T> toDTOFunction) {
+
+		PageJSONParser pageJSONParser = new PageJSONParser(toDTOFunction);
+
+		return (Page<T>)pageJSONParser.parseToDTO(json);
+	}
+
+	public T fetchFirstItem() {
+		Iterator<T> iterator = _items.iterator();
+
+		if (iterator.hasNext()) {
+			return iterator.next();
+		}
+
+		return null;
+	}
+
+	public Map<String, Map<String, String>> getActions() {
+		return _actions;
+	}
+
+	public List<Facet> getFacets() {
+		return _facets;
+	}
+
+	public Collection<T> getItems() {
+		return _items;
+	}
+
+	public long getLastPage() {
+		if (_totalCount == 0) {
+			return 1;
+		}
+
+		return -Math.floorDiv(-_totalCount, _pageSize);
+	}
+
+	public long getPage() {
+		return _page;
+	}
+
+	public long getPageSize() {
+		return _pageSize;
+	}
+
+	public long getTotalCount() {
+		return _totalCount;
+	}
+
+	public boolean hasNext() {
+		if (getLastPage() > _page) {
+			return true;
+		}
+
+		return false;
+	}
+
+	public boolean hasPrevious() {
+		if (_page > 1) {
+			return true;
+		}
+
+		return false;
+	}
+
+	public void setActions(Map<String, Map<String, String>> actions) {
+		_actions = actions;
+	}
+
+	public void setFacets(List<Facet> facets) {
+		_facets = facets;
+	}
+
+	public void setItems(Collection<T> items) {
+		_items = items;
+	}
+
+	public void setPage(long page) {
+		_page = page;
+	}
+
+	public void setPageSize(long pageSize) {
+		_pageSize = pageSize;
+	}
+
+	public void setTotalCount(long totalCount) {
+		_totalCount = totalCount;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder("{\"actions\": ");
+
+		sb.append(_toString((Map)_actions));
+		sb.append(", \"items\": [");
+
+		Iterator<T> iterator = _items.iterator();
+
+		while (iterator.hasNext()) {
+			sb.append(iterator.next());
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("], \"page\": ");
+		sb.append(_page);
+		sb.append(", \"pageSize\": ");
+		sb.append(_pageSize);
+		sb.append(", \"totalCount\": ");
+		sb.append(_totalCount);
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static class PageJSONParser<T> extends BaseJSONParser<Page> {
+
+		public PageJSONParser() {
+			_toDTOFunction = null;
+		}
+
+		public PageJSONParser(Function<String, T> toDTOFunction) {
+			_toDTOFunction = toDTOFunction;
+		}
+
+		@Override
+		protected Page createDTO() {
+			return new Page();
+		}
+
+		@Override
+		protected Page[] createDTOArray(int size) {
+			return new Page[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "actions")) {
+				return true;
+			}
+			else if (Objects.equals(jsonParserFieldName, "facets")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "items")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "lastPage")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "page")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "pageSize")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "totalCount")) {
+				return false;
+			}
+			else {
+				throw new IllegalArgumentException(
+					"Unsupported field name " + jsonParserFieldName);
+			}
+		}
+
+		@Override
+		protected void setField(
+			Page page, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "actions")) {
+				if (jsonParserFieldValue != null) {
+					page.setActions(
+						(Map<String, Map<String, String>>)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "facets")) {
+				if (jsonParserFieldValue == null) {
+					return;
+				}
+
+				List<Facet> facets = new ArrayList<>();
+
+				for (Object object1 : (Object[])jsonParserFieldValue) {
+					List<Facet.FacetValue> facetValues = new ArrayList<>();
+
+					Map<String, Object> jsonParserFieldValuesMap =
+						this.parseToMap((String)object1);
+
+					for (Object object2 :
+							(Object[])jsonParserFieldValuesMap.get(
+								"facetValues")) {
+
+						Map<String, Object> facetValueMap = this.parseToMap(
+							(String)object2);
+
+						facetValues.add(
+							new Facet.FacetValue(
+								Integer.valueOf(
+									(String)facetValueMap.get(
+										"numberOfOccurrences")),
+								(String)facetValueMap.get("term")));
+					}
+
+					facets.add(
+						new Facet(
+							(String)jsonParserFieldValuesMap.get(
+								"facetCriteria"),
+							facetValues));
+				}
+
+				page.setFacets(facets);
+			}
+			else if (Objects.equals(jsonParserFieldName, "items")) {
+				if (jsonParserFieldValue != null) {
+					List<T> items = new ArrayList<>();
+
+					for (Object object : (Object[])jsonParserFieldValue) {
+						items.add(_toDTOFunction.apply((String)object));
+					}
+
+					page.setItems(items);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "lastPage")) {
+			}
+			else if (Objects.equals(jsonParserFieldName, "page")) {
+				if (jsonParserFieldValue != null) {
+					page.setPage(Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "pageSize")) {
+				if (jsonParserFieldValue != null) {
+					page.setPageSize(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "totalCount")) {
+				if (jsonParserFieldValue != null) {
+					page.setTotalCount(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else {
+				throw new IllegalArgumentException(
+					"Unsupported field name " + jsonParserFieldName);
+			}
+		}
+
+		private final Function<String, T> _toDTOFunction;
+
+	}
+
+	private String _toString(Map<String, Object> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		Set<Map.Entry<String, Object>> entries = map.entrySet();
+
+		Iterator<Map.Entry<String, Object>> iterator = entries.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, Object> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (value instanceof Map) {
+				sb.append(_toString((Map)value));
+			}
+			else {
+				sb.append("\"");
+				sb.append(value);
+				sb.append("\"");
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private Map<String, Map<String, String>> _actions;
+	private List<Facet> _facets = new ArrayList<>();
+	private Collection<T> _items;
+	private long _page;
+	private long _pageSize;
+	private long _totalCount;
+
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/src/main/java/com/liferay/graphql/bug/rest/client/pagination/Pagination.java
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/src/main/java/com/liferay/graphql/bug/rest/client/pagination/Pagination.java
@@ -1,0 +1,65 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.graphql.bug.rest.client.pagination;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+public class Pagination {
+
+	public static Pagination of(int page, int pageSize) {
+		return new Pagination(page, pageSize);
+	}
+
+	public int getEndPosition() {
+		if ((_page < 0) || (_pageSize < 0)) {
+			return -1;
+		}
+
+		return _page * _pageSize;
+	}
+
+	public int getPage() {
+		return _page;
+	}
+
+	public int getPageSize() {
+		return _pageSize;
+	}
+
+	public int getStartPosition() {
+		if ((_page < 0) || (_pageSize < 0)) {
+			return -1;
+		}
+
+		return (_page - 1) * _pageSize;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder("{\"page\": ");
+
+		sb.append(_page);
+		sb.append(", \"pageSize\": ");
+		sb.append(_pageSize);
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private Pagination(int page, int pageSize) {
+		_page = page;
+		_pageSize = pageSize;
+	}
+
+	private final int _page;
+	private final int _pageSize;
+
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/src/main/java/com/liferay/graphql/bug/rest/client/permission/Permission.java
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/src/main/java/com/liferay/graphql/bug/rest/client/permission/Permission.java
@@ -1,0 +1,134 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.graphql.bug.rest.client.permission;
+
+import com.liferay.graphql.bug.rest.client.json.BaseJSONParser;
+
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+public class Permission {
+
+	public static Permission toDTO(String json) {
+		PermissionJSONParser<Permission> permissionJSONParser =
+			new PermissionJSONParser();
+
+		return permissionJSONParser.parseToDTO(json);
+	}
+
+	public Object[] getActionIds() {
+		return actionIds;
+	}
+
+	public String getRoleName() {
+		return roleName;
+	}
+
+	public void setActionIds(Object[] actionIds) {
+		this.actionIds = actionIds;
+	}
+
+	public void setRoleName(String roleName) {
+		this.roleName = roleName;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (actionIds != null) {
+			sb.append("\"actionIds\": [");
+
+			for (int i = 0; i < actionIds.length; i++) {
+				sb.append("\"");
+				sb.append(actionIds[i]);
+				sb.append("\"");
+
+				if ((i + 1) < actionIds.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (roleName != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"roleName\": \"");
+			sb.append(roleName);
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	protected Object[] actionIds;
+	protected String roleName;
+
+	private static class PermissionJSONParser<T>
+		extends BaseJSONParser<Permission> {
+
+		@Override
+		protected Permission createDTO() {
+			return new Permission();
+		}
+
+		@Override
+		protected Permission[] createDTOArray(int size) {
+			return new Permission[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "actionIds")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "roleName")) {
+				return false;
+			}
+			else {
+				throw new IllegalArgumentException(
+					"Unsupported field name " + jsonParserFieldName);
+			}
+		}
+
+		@Override
+		protected void setField(
+			Permission permission, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "actionIds")) {
+				if (jsonParserFieldValue != null) {
+					permission.setActionIds((Object[])jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "roleName")) {
+				if (jsonParserFieldValue != null) {
+					permission.setRoleName((String)jsonParserFieldValue);
+				}
+			}
+			else {
+				throw new IllegalArgumentException(
+					"Unsupported field name " + jsonParserFieldName);
+			}
+		}
+
+	}
+
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/src/main/java/com/liferay/graphql/bug/rest/client/problem/Problem.java
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/src/main/java/com/liferay/graphql/bug/rest/client/problem/Problem.java
@@ -1,0 +1,196 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.graphql.bug.rest.client.problem;
+
+import com.liferay.graphql.bug.rest.client.json.BaseJSONParser;
+
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+public class Problem {
+
+	public static Problem toDTO(String json) {
+		ProblemJSONParser<Problem> problemJSONParser = new ProblemJSONParser();
+
+		return problemJSONParser.parseToDTO(json);
+	}
+
+	public static class ProblemException extends Exception {
+
+		private Problem _problem;
+
+		public Problem getProblem() {
+			return _problem;
+		}
+
+		public ProblemException(Problem problem) {
+			super(problem.getTitle());
+
+			_problem = problem;
+		}
+
+	}
+
+	public String getDetail() {
+		return detail;
+	}
+
+	public String getStatus() {
+		return status;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setDetail(String detail) {
+		this.detail = detail;
+	}
+
+	public void setStatus(String status) {
+		this.status = status;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (detail != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"detail\": \"");
+			sb.append(detail);
+			sb.append("\"");
+		}
+
+		if (status != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"status\": \"");
+			sb.append(status);
+			sb.append("\"");
+		}
+
+		if (title != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": \"");
+			sb.append(title);
+			sb.append("\"");
+		}
+
+		if (type != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"type\": \"");
+			sb.append(type);
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	protected String detail;
+	protected String status;
+	protected String title;
+	protected String type;
+
+	private static class ProblemJSONParser<T> extends BaseJSONParser<Problem> {
+
+		@Override
+		protected Problem createDTO() {
+			return new Problem();
+		}
+
+		@Override
+		protected Problem[] createDTOArray(int size) {
+			return new Problem[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "detail")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "status")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				return false;
+			}
+			else {
+				throw new IllegalArgumentException(
+					"Unsupported field name " + jsonParserFieldName);
+			}
+		}
+
+		@Override
+		protected void setField(
+			Problem problem, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "detail")) {
+				if (jsonParserFieldValue != null) {
+					problem.setDetail((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "status")) {
+				if (jsonParserFieldValue != null) {
+					problem.setStatus((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				if (jsonParserFieldValue != null) {
+					problem.setTitle((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "type")) {
+				if (jsonParserFieldValue != null) {
+					problem.setType((String)jsonParserFieldValue);
+				}
+			}
+			else {
+				throw new IllegalArgumentException(
+					"Unsupported field name " + jsonParserFieldName);
+			}
+		}
+
+	}
+
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/src/main/java/com/liferay/graphql/bug/rest/client/resource/v1_0/MessageResource.java
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/src/main/java/com/liferay/graphql/bug/rest/client/resource/v1_0/MessageResource.java
@@ -1,0 +1,391 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.graphql.bug.rest.client.resource.v1_0;
+
+import com.liferay.graphql.bug.rest.client.dto.v1_0.Message;
+import com.liferay.graphql.bug.rest.client.http.HttpInvoker;
+import com.liferay.graphql.bug.rest.client.pagination.Page;
+import com.liferay.graphql.bug.rest.client.problem.Problem;
+import com.liferay.graphql.bug.rest.client.serdes.v1_0.MessageSerDes;
+
+import java.net.URL;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+public interface MessageResource {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public Page<Message> getMessagesPage(String[] keys) throws Exception;
+
+	public HttpInvoker.HttpResponse getMessagesPageHttpResponse(String[] keys)
+		throws Exception;
+
+	public void postMessagesPageExportBatch(
+			String[] keys, String callbackURL, String contentType,
+			String fieldNames)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postMessagesPageExportBatchHttpResponse(
+			String[] keys, String callbackURL, String contentType,
+			String fieldNames)
+		throws Exception;
+
+	public static class Builder {
+
+		public Builder authentication(String login, String password) {
+			_login = login;
+			_password = password;
+
+			return this;
+		}
+
+		public Builder bearerToken(String token) {
+			return header("Authorization", "Bearer " + token);
+		}
+
+		public MessageResource build() {
+			return new MessageResourceImpl(this);
+		}
+
+		public Builder contextPath(String contextPath) {
+			_contextPath = contextPath;
+
+			return this;
+		}
+
+		public Builder endpoint(String address, String scheme) {
+			String[] addressParts = address.split(":");
+
+			String host = addressParts[0];
+
+			int port = 443;
+
+			if (addressParts.length > 1) {
+				String portString = addressParts[1];
+
+				try {
+					port = Integer.parseInt(portString);
+				}
+				catch (NumberFormatException numberFormatException) {
+					throw new IllegalArgumentException(
+						"Unable to parse port from " + portString);
+				}
+			}
+
+			return endpoint(host, port, scheme);
+		}
+
+		public Builder endpoint(String host, int port, String scheme) {
+			_host = host;
+			_port = port;
+			_scheme = scheme;
+
+			return this;
+		}
+
+		public Builder endpoint(URL url) {
+			return endpoint(url.getHost(), url.getPort(), url.getProtocol());
+		}
+
+		public Builder header(String key, String value) {
+			_headers.put(key, value);
+
+			return this;
+		}
+
+		public Builder locale(Locale locale) {
+			_locale = locale;
+
+			return this;
+		}
+
+		public Builder parameter(String key, String value) {
+			_parameters.put(key, value);
+
+			return this;
+		}
+
+		public Builder parameters(String... parameters) {
+			if ((parameters.length % 2) != 0) {
+				throw new IllegalArgumentException(
+					"Parameters length is not an even number");
+			}
+
+			for (int i = 0; i < parameters.length; i += 2) {
+				String parameterName = String.valueOf(parameters[i]);
+				String parameterValue = String.valueOf(parameters[i + 1]);
+
+				_parameters.put(parameterName, parameterValue);
+			}
+
+			return this;
+		}
+
+		private Builder() {
+		}
+
+		private String _contextPath = "";
+		private Map<String, String> _headers = new LinkedHashMap<>();
+		private String _host = "localhost";
+		private Locale _locale;
+		private String _login = "";
+		private String _password = "";
+		private Map<String, String> _parameters = new LinkedHashMap<>();
+		private int _port = 8080;
+		private String _scheme = "http";
+
+	}
+
+	public static class MessageResourceImpl implements MessageResource {
+
+		public Page<Message> getMessagesPage(String[] keys) throws Exception {
+			HttpInvoker.HttpResponse httpResponse = getMessagesPageHttpResponse(
+				keys);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, MessageSerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse getMessagesPageHttpResponse(
+				String[] keys)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (keys != null) {
+				for (int i = 0; i < keys.length; i++) {
+					httpInvoker.parameter("keys", String.valueOf(keys[i]));
+				}
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-bug/v1.0/messages");
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public void postMessagesPageExportBatch(
+				String[] keys, String callbackURL, String contentType,
+				String fieldNames)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postMessagesPageExportBatchHttpResponse(
+					keys, callbackURL, contentType, fieldNames);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse postMessagesPageExportBatchHttpResponse(
+				String[] keys, String callbackURL, String contentType,
+				String fieldNames)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body("[]", "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (keys != null) {
+				for (int i = 0; i < keys.length; i++) {
+					httpInvoker.parameter("keys", String.valueOf(keys[i]));
+				}
+			}
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			if (contentType != null) {
+				httpInvoker.parameter(
+					"contentType", String.valueOf(contentType));
+			}
+
+			if (fieldNames != null) {
+				httpInvoker.parameter("fieldNames", String.valueOf(fieldNames));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-bug/v1.0/messages/export-batch");
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		private MessageResourceImpl(Builder builder) {
+			_builder = builder;
+		}
+
+		private static final Logger _logger = Logger.getLogger(
+			MessageResource.class.getName());
+
+		private Builder _builder;
+
+	}
+
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/src/main/java/com/liferay/graphql/bug/rest/client/serdes/v1_0/MessageSerDes.java
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-client/src/main/java/com/liferay/graphql/bug/rest/client/serdes/v1_0/MessageSerDes.java
@@ -1,0 +1,254 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.graphql.bug.rest.client.serdes.v1_0;
+
+import com.liferay.graphql.bug.rest.client.dto.v1_0.Message;
+import com.liferay.graphql.bug.rest.client.json.BaseJSONParser;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+public class MessageSerDes {
+
+	public static Message toDTO(String json) {
+		MessageJSONParser messageJSONParser = new MessageJSONParser();
+
+		return messageJSONParser.parseToDTO(json);
+	}
+
+	public static Message[] toDTOs(String json) {
+		MessageJSONParser messageJSONParser = new MessageJSONParser();
+
+		return messageJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(Message message) {
+		if (message == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (message.getKey() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"key\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(message.getKey()));
+
+			sb.append("\"");
+		}
+
+		if (message.getLanguageId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"languageId\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(message.getLanguageId()));
+
+			sb.append("\"");
+		}
+
+		if (message.getValue() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"value\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(message.getValue()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		MessageJSONParser messageJSONParser = new MessageJSONParser();
+
+		return messageJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(Message message) {
+		if (message == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (message.getKey() == null) {
+			map.put("key", null);
+		}
+		else {
+			map.put("key", String.valueOf(message.getKey()));
+		}
+
+		if (message.getLanguageId() == null) {
+			map.put("languageId", null);
+		}
+		else {
+			map.put("languageId", String.valueOf(message.getLanguageId()));
+		}
+
+		if (message.getValue() == null) {
+			map.put("value", null);
+		}
+		else {
+			map.put("value", String.valueOf(message.getValue()));
+		}
+
+		return map;
+	}
+
+	public static class MessageJSONParser extends BaseJSONParser<Message> {
+
+		@Override
+		protected Message createDTO() {
+			return new Message();
+		}
+
+		@Override
+		protected Message[] createDTOArray(int size) {
+			return new Message[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "key")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "languageId")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "value")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			Message message, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "key")) {
+				if (jsonParserFieldValue != null) {
+					message.setKey((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "languageId")) {
+				if (jsonParserFieldValue != null) {
+					message.setLanguageId((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "value")) {
+				if (jsonParserFieldValue != null) {
+					message.setValue((String)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/bnd.bnd
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Graphql Bug REST Implementation
+Bundle-SymbolicName: com.liferay.graphql.bug.rest.impl
+Bundle-Version: 1.0.0

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/build.gradle
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/build.gradle
@@ -1,0 +1,19 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
+	compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3.2"
+	compileOnly group: "javax.validation", name: "validation-api", version: "2.0.1.Final"
+	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
+	compileOnly group: "org.apache.cxf", name: "cxf-core", version: "3.4.10"
+	compileOnly group: "org.apache.cxf", name: "cxf-rt-frontend-jaxrs", version: "3.4.10"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.4.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:headless-graphql-bug:headless-graphql-bug-rest-api")
+	compileOnly project(":apps:portal-odata:portal-odata-api")
+	compileOnly project(":apps:portal-search:portal-search-api")
+	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
+	compileOnly project(":core:petra:petra-function")
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/rest-config.yaml
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/rest-config.yaml
@@ -1,0 +1,11 @@
+apiDir: "../headless-graphql-bug-rest-api/src/main/java"
+apiPackagePath: "com.liferay.graphql.bug.rest"
+application:
+    baseURI: "/headless-bug"
+    className: "HeadlessBugRESTApplication"
+    name: "Liferay.Headless.Bug.REST"
+author: "Thiago Buarque"
+clientDir: "../headless-graphql-bug-rest-client/src/main/java"
+compatibilityVersion: 6
+forcePredictableOperationId: true
+testDir: "../headless-graphql-bug-rest-test/src/testIntegration/java"

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/rest-openapi.yaml
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/rest-openapi.yaml
@@ -1,0 +1,44 @@
+components:
+    schemas:
+        Message:
+            properties:
+                key:
+                    type: string
+                languageId:
+                    type: string
+                value:
+                    type: string
+            type: object
+info:
+    license:
+        name: "Apache 2.0"
+        url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+    title: "Graphql Bug"
+    version: v1.0
+openapi: 3.0.1
+paths:
+    "/messages":
+        get:
+            operationId: getMessagesPage
+            parameters:
+                - in: query
+                  name: keys
+                  required: true
+                  schema:
+                      items:
+                        type: string
+                      type: array
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/Message"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/Message"
+                                type: array
+            tags: ["Message"]

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/src/main/java/com/liferay/graphql/bug/rest/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/src/main/java/com/liferay/graphql/bug/rest/internal/graphql/mutation/v1_0/Mutation.java
@@ -1,0 +1,136 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.graphql.bug.rest.internal.graphql.mutation.v1_0;
+
+import com.liferay.graphql.bug.rest.resource.v1_0.MessageResource;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+
+import java.util.function.BiFunction;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.osgi.service.component.ComponentServiceObjects;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+public class Mutation {
+
+	public static void setMessageResourceComponentServiceObjects(
+		ComponentServiceObjects<MessageResource>
+			messageResourceComponentServiceObjects) {
+
+		_messageResourceComponentServiceObjects =
+			messageResourceComponentServiceObjects;
+	}
+
+	@GraphQLField
+	public Response createMessagesPageExportBatch(
+			@GraphQLName("keys") String[] keys,
+			@GraphQLName("callbackURL") String callbackURL,
+			@GraphQLName("contentType") String contentType,
+			@GraphQLName("fieldNames") String fieldNames)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_messageResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			messageResource -> messageResource.postMessagesPageExportBatch(
+				keys, callbackURL, contentType, fieldNames));
+	}
+
+	private <T, R, E1 extends Throwable, E2 extends Throwable> R
+			_applyComponentServiceObjects(
+				ComponentServiceObjects<T> componentServiceObjects,
+				UnsafeConsumer<T, E1> unsafeConsumer,
+				UnsafeFunction<T, R, E2> unsafeFunction)
+		throws E1, E2 {
+
+		T resource = componentServiceObjects.getService();
+
+		try {
+			unsafeConsumer.accept(resource);
+
+			return unsafeFunction.apply(resource);
+		}
+		finally {
+			componentServiceObjects.ungetService(resource);
+		}
+	}
+
+	private <T, E1 extends Throwable, E2 extends Throwable> void
+			_applyVoidComponentServiceObjects(
+				ComponentServiceObjects<T> componentServiceObjects,
+				UnsafeConsumer<T, E1> unsafeConsumer,
+				UnsafeConsumer<T, E2> unsafeFunction)
+		throws E1, E2 {
+
+		T resource = componentServiceObjects.getService();
+
+		try {
+			unsafeConsumer.accept(resource);
+
+			unsafeFunction.accept(resource);
+		}
+		finally {
+			componentServiceObjects.ungetService(resource);
+		}
+	}
+
+	private void _populateResourceContext(MessageResource messageResource)
+		throws Exception {
+
+		messageResource.setContextAcceptLanguage(_acceptLanguage);
+		messageResource.setContextCompany(_company);
+		messageResource.setContextHttpServletRequest(_httpServletRequest);
+		messageResource.setContextHttpServletResponse(_httpServletResponse);
+		messageResource.setContextUriInfo(_uriInfo);
+		messageResource.setContextUser(_user);
+		messageResource.setGroupLocalService(_groupLocalService);
+		messageResource.setRoleLocalService(_roleLocalService);
+
+		messageResource.setVulcanBatchEngineExportTaskResource(
+			_vulcanBatchEngineExportTaskResource);
+
+		messageResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
+	}
+
+	private static ComponentServiceObjects<MessageResource>
+		_messageResourceComponentServiceObjects;
+
+	private AcceptLanguage _acceptLanguage;
+	private com.liferay.portal.kernel.model.Company _company;
+	private GroupLocalService _groupLocalService;
+	private HttpServletRequest _httpServletRequest;
+	private HttpServletResponse _httpServletResponse;
+	private RoleLocalService _roleLocalService;
+	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
+	private UriInfo _uriInfo;
+	private com.liferay.portal.kernel.model.User _user;
+	private VulcanBatchEngineExportTaskResource
+		_vulcanBatchEngineExportTaskResource;
+	private VulcanBatchEngineImportTaskResource
+		_vulcanBatchEngineImportTaskResource;
+
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/src/main/java/com/liferay/graphql/bug/rest/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/src/main/java/com/liferay/graphql/bug/rest/internal/graphql/query/v1_0/Query.java
@@ -1,0 +1,143 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.graphql.bug.rest.internal.graphql.query.v1_0;
+
+import com.liferay.graphql.bug.rest.dto.v1_0.Message;
+import com.liferay.graphql.bug.rest.resource.v1_0.MessageResource;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.pagination.Page;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
+import org.osgi.service.component.ComponentServiceObjects;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+public class Query {
+
+	public static void setMessageResourceComponentServiceObjects(
+		ComponentServiceObjects<MessageResource>
+			messageResourceComponentServiceObjects) {
+
+		_messageResourceComponentServiceObjects =
+			messageResourceComponentServiceObjects;
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {messages(keys: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField
+	public MessagePage messages(@GraphQLName("keys") String[] keys)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_messageResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			messageResource -> new MessagePage(
+				messageResource.getMessagesPage(keys)));
+	}
+
+	@GraphQLName("MessagePage")
+	public class MessagePage {
+
+		public MessagePage(Page messagePage) {
+			actions = messagePage.getActions();
+
+			items = messagePage.getItems();
+			lastPage = messagePage.getLastPage();
+			page = messagePage.getPage();
+			pageSize = messagePage.getPageSize();
+			totalCount = messagePage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Map<String, Map<String, String>> actions;
+
+		@GraphQLField
+		protected java.util.Collection<Message> items;
+
+		@GraphQLField
+		protected long lastPage;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	private <T, R, E1 extends Throwable, E2 extends Throwable> R
+			_applyComponentServiceObjects(
+				ComponentServiceObjects<T> componentServiceObjects,
+				UnsafeConsumer<T, E1> unsafeConsumer,
+				UnsafeFunction<T, R, E2> unsafeFunction)
+		throws E1, E2 {
+
+		T resource = componentServiceObjects.getService();
+
+		try {
+			unsafeConsumer.accept(resource);
+
+			return unsafeFunction.apply(resource);
+		}
+		finally {
+			componentServiceObjects.ungetService(resource);
+		}
+	}
+
+	private void _populateResourceContext(MessageResource messageResource)
+		throws Exception {
+
+		messageResource.setContextAcceptLanguage(_acceptLanguage);
+		messageResource.setContextCompany(_company);
+		messageResource.setContextHttpServletRequest(_httpServletRequest);
+		messageResource.setContextHttpServletResponse(_httpServletResponse);
+		messageResource.setContextUriInfo(_uriInfo);
+		messageResource.setContextUser(_user);
+		messageResource.setGroupLocalService(_groupLocalService);
+		messageResource.setRoleLocalService(_roleLocalService);
+	}
+
+	private static ComponentServiceObjects<MessageResource>
+		_messageResourceComponentServiceObjects;
+
+	private AcceptLanguage _acceptLanguage;
+	private com.liferay.portal.kernel.model.Company _company;
+	private BiFunction<Object, String, Filter> _filterBiFunction;
+	private GroupLocalService _groupLocalService;
+	private HttpServletRequest _httpServletRequest;
+	private HttpServletResponse _httpServletResponse;
+	private RoleLocalService _roleLocalService;
+	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
+	private UriInfo _uriInfo;
+	private com.liferay.portal.kernel.model.User _user;
+
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/src/main/java/com/liferay/graphql/bug/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/src/main/java/com/liferay/graphql/bug/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -1,0 +1,95 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.graphql.bug.rest.internal.graphql.servlet.v1_0;
+
+import com.liferay.graphql.bug.rest.internal.graphql.mutation.v1_0.Mutation;
+import com.liferay.graphql.bug.rest.internal.graphql.query.v1_0.Query;
+import com.liferay.graphql.bug.rest.internal.resource.v1_0.MessageResourceImpl;
+import com.liferay.graphql.bug.rest.resource.v1_0.MessageResource;
+import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.vulcan.graphql.servlet.ServletData;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Component(service = ServletData.class)
+@Generated("")
+public class ServletDataImpl implements ServletData {
+
+	@Activate
+	public void activate(BundleContext bundleContext) {
+		Mutation.setMessageResourceComponentServiceObjects(
+			_messageResourceComponentServiceObjects);
+
+		Query.setMessageResourceComponentServiceObjects(
+			_messageResourceComponentServiceObjects);
+	}
+
+	public String getApplicationName() {
+		return "Liferay.Headless.Bug.REST";
+	}
+
+	@Override
+	public Mutation getMutation() {
+		return new Mutation();
+	}
+
+	@Override
+	public String getPath() {
+		return "/headless-bug-graphql/v1_0";
+	}
+
+	@Override
+	public Query getQuery() {
+		return new Query();
+	}
+
+	public ObjectValuePair<Class<?>, String> getResourceMethodObjectValuePair(
+		String methodName, boolean mutation) {
+
+		if (mutation) {
+			return _resourceMethodObjectValuePairs.get(
+				"mutation#" + methodName);
+		}
+
+		return _resourceMethodObjectValuePairs.get("query#" + methodName);
+	}
+
+	private static final Map<String, ObjectValuePair<Class<?>, String>>
+		_resourceMethodObjectValuePairs =
+			new HashMap<String, ObjectValuePair<Class<?>, String>>() {
+				{
+					put(
+						"mutation#createMessagesPageExportBatch",
+						new ObjectValuePair<>(
+							MessageResourceImpl.class,
+							"postMessagesPageExportBatch"));
+
+					put(
+						"query#messages",
+						new ObjectValuePair<>(
+							MessageResourceImpl.class, "getMessagesPage"));
+				}
+			};
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<MessageResource>
+		_messageResourceComponentServiceObjects;
+
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/src/main/java/com/liferay/graphql/bug/rest/internal/jaxrs/application/HeadlessBugRESTApplication.java
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/src/main/java/com/liferay/graphql/bug/rest/internal/jaxrs/application/HeadlessBugRESTApplication.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.graphql.bug.rest.internal.jaxrs.application;
+
+import javax.annotation.Generated;
+
+import javax.ws.rs.core.Application;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Component(
+	property = {
+		"liferay.jackson=false", "osgi.jaxrs.application.base=/headless-bug",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=Liferay.Vulcan)",
+		"osgi.jaxrs.name=Liferay.Headless.Bug.REST"
+	},
+	service = Application.class
+)
+@Generated("")
+public class HeadlessBugRESTApplication extends Application {
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/src/main/java/com/liferay/graphql/bug/rest/internal/resource/v1_0/BaseMessageResourceImpl.java
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/src/main/java/com/liferay/graphql/bug/rest/internal/resource/v1_0/BaseMessageResourceImpl.java
@@ -1,0 +1,559 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.graphql.bug.rest.internal.resource.v1_0;
+
+import com.liferay.graphql.bug.rest.dto.v1_0.Message;
+import com.liferay.graphql.bug.rest.resource.v1_0.MessageResource;
+import com.liferay.petra.function.UnsafeBiConsumer;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParser;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortField;
+import com.liferay.portal.odata.sort.SortParser;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+import com.liferay.portal.vulcan.util.ActionUtil;
+
+import java.io.Serializable;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+@javax.ws.rs.Path("/v1.0")
+public abstract class BaseMessageResourceImpl
+	implements EntityModelResource, MessageResource,
+			   VulcanBatchEngineTaskItemDelegate<Message> {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-bug/v1.0/messages'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "keys"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Message")}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path("/messages")
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<Message> getMessagesPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.QueryParam("keys")
+			String[] keys)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-bug/v1.0/messages/export-batch'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "keys"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "callbackURL"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "contentType"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fieldNames"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Message")}
+	)
+	@javax.ws.rs.Consumes("application/json")
+	@javax.ws.rs.Path("/messages/export-batch")
+	@javax.ws.rs.POST
+	@javax.ws.rs.Produces("application/json")
+	@Override
+	public Response postMessagesPageExportBatch(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.QueryParam("keys")
+			String[] keys,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("callbackURL")
+			String callbackURL,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.DefaultValue("JSON")
+			@javax.ws.rs.QueryParam("contentType")
+			String contentType,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("fieldNames")
+			String fieldNames)
+		throws Exception {
+
+		vulcanBatchEngineExportTaskResource.setContextAcceptLanguage(
+			contextAcceptLanguage);
+		vulcanBatchEngineExportTaskResource.setContextCompany(contextCompany);
+		vulcanBatchEngineExportTaskResource.setContextHttpServletRequest(
+			contextHttpServletRequest);
+		vulcanBatchEngineExportTaskResource.setContextUriInfo(contextUriInfo);
+		vulcanBatchEngineExportTaskResource.setContextUser(contextUser);
+		vulcanBatchEngineExportTaskResource.setGroupLocalService(
+			groupLocalService);
+
+		Response.ResponseBuilder responseBuilder = Response.accepted();
+
+		return responseBuilder.entity(
+			vulcanBatchEngineExportTaskResource.postExportTask(
+				Message.class.getName(), callbackURL, contentType, fieldNames)
+		).build();
+	}
+
+	@Override
+	@SuppressWarnings("PMD.UnusedLocalVariable")
+	public void create(
+			Collection<Message> messages, Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Override
+	public void delete(
+			Collection<Message> messages, Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	@Override
+	public EntityModel getEntityModel(Map<String, List<String>> multivaluedMap)
+		throws Exception {
+
+		return getEntityModel(
+			new MultivaluedHashMap<String, Object>(multivaluedMap));
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap)
+		throws Exception {
+
+		return null;
+	}
+
+	public String getResourceName() {
+		return "Message";
+	}
+
+	public String getVersion() {
+		return "v1.0";
+	}
+
+	@Override
+	public Page<Message> read(
+			Filter filter, Pagination pagination, Sort[] sorts,
+			Map<String, Serializable> parameters, String search)
+		throws Exception {
+
+		return getMessagesPage((String[])parameters.get("keys"));
+	}
+
+	@Override
+	public void setLanguageId(String languageId) {
+		this.contextAcceptLanguage = new AcceptLanguage() {
+
+			@Override
+			public List<Locale> getLocales() {
+				return null;
+			}
+
+			@Override
+			public String getPreferredLanguageId() {
+				return languageId;
+			}
+
+			@Override
+			public Locale getPreferredLocale() {
+				return LocaleUtil.fromLanguageId(languageId);
+			}
+
+		};
+	}
+
+	@Override
+	public void update(
+			Collection<Message> messages, Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextBatchUnsafeBiConsumer(
+		UnsafeBiConsumer
+			<Collection<Message>, UnsafeFunction<Message, Message, Exception>,
+			 Exception> contextBatchUnsafeBiConsumer) {
+
+		this.contextBatchUnsafeBiConsumer = contextBatchUnsafeBiConsumer;
+	}
+
+	public void setContextBatchUnsafeConsumer(
+		UnsafeBiConsumer
+			<Collection<Message>, UnsafeConsumer<Message, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
+
+		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany) {
+
+		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser) {
+
+		this.contextUser = contextUser;
+	}
+
+	public void setExpressionConvert(
+		ExpressionConvert<Filter> expressionConvert) {
+
+		this.expressionConvert = expressionConvert;
+	}
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider) {
+
+		this.filterParserProvider = filterParserProvider;
+	}
+
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		this.groupLocalService = groupLocalService;
+	}
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService) {
+
+		this.resourceActionLocalService = resourceActionLocalService;
+	}
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this.resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	public void setRoleLocalService(RoleLocalService roleLocalService) {
+		this.roleLocalService = roleLocalService;
+	}
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider) {
+		this.sortParserProvider = sortParserProvider;
+	}
+
+	public void setVulcanBatchEngineExportTaskResource(
+		VulcanBatchEngineExportTaskResource
+			vulcanBatchEngineExportTaskResource) {
+
+		this.vulcanBatchEngineExportTaskResource =
+			vulcanBatchEngineExportTaskResource;
+	}
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
+	@Override
+	public Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		try {
+			EntityModel entityModel = getEntityModel(multivaluedMap);
+
+			FilterParser filterParser = filterParserProvider.provide(
+				entityModel);
+
+			com.liferay.portal.odata.filter.Filter oDataFilter =
+				new com.liferay.portal.odata.filter.Filter(
+					filterParser.parse(filterString));
+
+			return expressionConvert.convert(
+				oDataFilter.getExpression(),
+				contextAcceptLanguage.getPreferredLocale(), entityModel);
+		}
+		catch (Exception exception) {
+			_log.error("Invalid filter " + filterString, exception);
+
+			return null;
+		}
+	}
+
+	@Override
+	public Sort[] toSorts(String sortString) {
+		if (Validator.isNull(sortString)) {
+			return null;
+		}
+
+		try {
+			SortParser sortParser = sortParserProvider.provide(
+				getEntityModel(Collections.emptyMap()));
+
+			if (sortParser == null) {
+				return null;
+			}
+
+			com.liferay.portal.odata.sort.Sort oDataSort =
+				new com.liferay.portal.odata.sort.Sort(
+					sortParser.parse(sortString));
+
+			List<SortField> sortFields = oDataSort.getSortFields();
+
+			Sort[] sorts = new Sort[sortFields.size()];
+
+			for (int i = 0; i < sortFields.size(); i++) {
+				SortField sortField = sortFields.get(i);
+
+				sorts[i] = new Sort(
+					sortField.getSortableFieldName(
+						contextAcceptLanguage.getPreferredLocale()),
+					!sortField.isAscending());
+			}
+
+			return sorts;
+		}
+		catch (Exception exception) {
+			_log.error("Invalid sort " + sortString, exception);
+
+			return new Sort[0];
+		}
+	}
+
+	protected Map<String, String> addAction(
+		String actionName,
+		com.liferay.portal.kernel.model.GroupedModel groupedModel,
+		String methodName) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), groupedModel, methodName,
+			contextScopeChecker, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName, Long ownerId,
+		String permissionName, Long siteId) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			ownerId, permissionName, siteId, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName,
+		ModelResourcePermission modelResourcePermission) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			modelResourcePermission, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, String methodName, String permissionName,
+		Long siteId) {
+
+		return addAction(
+			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transform(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> R[] transform(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transformToArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] transformToLongArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(collection, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransform(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransform(collection, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransform(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransformToList(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] unsafeTransformToLongArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(
+			collection, unsafeFunction);
+	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected UnsafeBiConsumer
+		<Collection<Message>, UnsafeFunction<Message, Message, Exception>,
+		 Exception> contextBatchUnsafeBiConsumer;
+	protected UnsafeBiConsumer
+		<Collection<Message>, UnsafeConsumer<Message, Exception>, Exception>
+			contextBatchUnsafeConsumer;
+	protected com.liferay.portal.kernel.model.Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected HttpServletResponse contextHttpServletResponse;
+	protected Object contextScopeChecker;
+	protected UriInfo contextUriInfo;
+	protected com.liferay.portal.kernel.model.User contextUser;
+	protected ExpressionConvert<Filter> expressionConvert;
+	protected FilterParserProvider filterParserProvider;
+	protected GroupLocalService groupLocalService;
+	protected ResourceActionLocalService resourceActionLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+	protected RoleLocalService roleLocalService;
+	protected SortParserProvider sortParserProvider;
+	protected VulcanBatchEngineExportTaskResource
+		vulcanBatchEngineExportTaskResource;
+	protected VulcanBatchEngineImportTaskResource
+		vulcanBatchEngineImportTaskResource;
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseMessageResourceImpl.class);
+
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/src/main/java/com/liferay/graphql/bug/rest/internal/resource/v1_0/MessageResourceImpl.java
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/src/main/java/com/liferay/graphql/bug/rest/internal/resource/v1_0/MessageResourceImpl.java
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.graphql.bug.rest.internal.resource.v1_0;
+
+import com.liferay.graphql.bug.rest.resource.v1_0.MessageResource;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author Thiago Buarque
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0/message.properties",
+	scope = ServiceScope.PROTOTYPE, service = MessageResource.class
+)
+public class MessageResourceImpl extends BaseMessageResourceImpl {
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/src/main/java/com/liferay/graphql/bug/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/src/main/java/com/liferay/graphql/bug/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -1,0 +1,94 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.graphql.bug.rest.internal.resource.v1_0;
+
+import com.liferay.portal.vulcan.resource.OpenAPIResource;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.License;
+
+import java.lang.reflect.Method;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0/openapi.properties",
+	service = OpenAPIResourceImpl.class
+)
+@Generated("")
+@OpenAPIDefinition(
+	info = @Info(license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Graphql Bug", version = "v1.0")
+)
+@Path("/v1.0")
+public class OpenAPIResourceImpl {
+
+	@GET
+	@Path("/openapi.{type:json|yaml}")
+	@Produces({MediaType.APPLICATION_JSON, "application/yaml"})
+	public Response getOpenAPI(
+			@Context HttpServletRequest httpServletRequest,
+			@PathParam("type") String type, @Context UriInfo uriInfo)
+		throws Exception {
+
+		Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
+
+		try {
+			Method method = clazz.getMethod(
+				"getOpenAPI", HttpServletRequest.class, Set.class, String.class,
+				UriInfo.class);
+
+			return (Response)method.invoke(
+				_openAPIResource, httpServletRequest, _resourceClasses, type,
+				uriInfo);
+		}
+		catch (NoSuchMethodException noSuchMethodException1) {
+			try {
+				Method method = clazz.getMethod(
+					"getOpenAPI", Set.class, String.class, UriInfo.class);
+
+				return (Response)method.invoke(
+					_openAPIResource, _resourceClasses, type, uriInfo);
+			}
+			catch (NoSuchMethodException noSuchMethodException2) {
+				return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			}
+		}
+	}
+
+	@Reference
+	private OpenAPIResource _openAPIResource;
+
+	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
+		{
+			add(MessageResourceImpl.class);
+
+			add(OpenAPIResourceImpl.class);
+		}
+	};
+
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/src/main/java/com/liferay/graphql/bug/rest/internal/resource/v1_0/factory/MessageResourceFactoryImpl.java
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/src/main/java/com/liferay/graphql/bug/rest/internal/resource/v1_0/factory/MessageResourceFactoryImpl.java
@@ -1,0 +1,326 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.graphql.bug.rest.internal.resource.v1_0.factory;
+
+import com.liferay.graphql.bug.rest.internal.security.permission.LiberalPermissionChecker;
+import com.liferay.graphql.bug.rest.resource.v1_0.MessageResource;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Component(
+	property = "resource.locator.key=/headless-bug/v1.0/Message",
+	service = MessageResource.Factory.class
+)
+@Generated("")
+public class MessageResourceFactoryImpl implements MessageResource.Factory {
+
+	@Override
+	public MessageResource.Builder create() {
+		return new MessageResource.Builder() {
+
+			@Override
+			public MessageResource build() {
+				if (_user == null) {
+					throw new IllegalArgumentException("User is not set");
+				}
+
+				Function<InvocationHandler, MessageResource>
+					messageResourceProxyProviderFunction =
+						ResourceProxyProviderFunctionHolder.
+							_messageResourceProxyProviderFunction;
+
+				return messageResourceProxyProviderFunction.apply(
+					(proxy, method, arguments) -> _invoke(
+						method, arguments, _checkPermissions,
+						_httpServletRequest, _httpServletResponse,
+						_preferredLocale, _uriInfo, _user));
+			}
+
+			@Override
+			public MessageResource.Builder checkPermissions(
+				boolean checkPermissions) {
+
+				_checkPermissions = checkPermissions;
+
+				return this;
+			}
+
+			@Override
+			public MessageResource.Builder httpServletRequest(
+				HttpServletRequest httpServletRequest) {
+
+				_httpServletRequest = httpServletRequest;
+
+				return this;
+			}
+
+			@Override
+			public MessageResource.Builder httpServletResponse(
+				HttpServletResponse httpServletResponse) {
+
+				_httpServletResponse = httpServletResponse;
+
+				return this;
+			}
+
+			@Override
+			public MessageResource.Builder preferredLocale(
+				Locale preferredLocale) {
+
+				_preferredLocale = preferredLocale;
+
+				return this;
+			}
+
+			@Override
+			public MessageResource.Builder uriInfo(UriInfo uriInfo) {
+				_uriInfo = uriInfo;
+
+				return this;
+			}
+
+			@Override
+			public MessageResource.Builder user(User user) {
+				_user = user;
+
+				return this;
+			}
+
+			private boolean _checkPermissions = true;
+			private HttpServletRequest _httpServletRequest;
+			private HttpServletResponse _httpServletResponse;
+			private Locale _preferredLocale;
+			private UriInfo _uriInfo;
+			private User _user;
+
+		};
+	}
+
+	private static Function<InvocationHandler, MessageResource>
+		_getProxyProviderFunction() {
+
+		Class<?> proxyClass = ProxyUtil.getProxyClass(
+			MessageResource.class.getClassLoader(), MessageResource.class);
+
+		try {
+			Constructor<MessageResource> constructor =
+				(Constructor<MessageResource>)proxyClass.getConstructor(
+					InvocationHandler.class);
+
+			return invocationHandler -> {
+				try {
+					return constructor.newInstance(invocationHandler);
+				}
+				catch (ReflectiveOperationException
+							reflectiveOperationException) {
+
+					throw new InternalError(reflectiveOperationException);
+				}
+			};
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			throw new InternalError(noSuchMethodException);
+		}
+	}
+
+	private Object _invoke(
+			Method method, Object[] arguments, boolean checkPermissions,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale preferredLocale,
+			UriInfo uriInfo, User user)
+		throws Throwable {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				_defaultPermissionCheckerFactory.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				new LiberalPermissionChecker(user));
+		}
+
+		MessageResource messageResource = _componentServiceObjects.getService();
+
+		messageResource.setContextAcceptLanguage(
+			new AcceptLanguageImpl(httpServletRequest, preferredLocale, user));
+
+		Company company = _companyLocalService.getCompany(user.getCompanyId());
+
+		messageResource.setContextCompany(company);
+
+		messageResource.setContextHttpServletRequest(httpServletRequest);
+		messageResource.setContextHttpServletResponse(httpServletResponse);
+		messageResource.setContextUriInfo(uriInfo);
+		messageResource.setContextUser(user);
+		messageResource.setExpressionConvert(_expressionConvert);
+		messageResource.setFilterParserProvider(_filterParserProvider);
+		messageResource.setGroupLocalService(_groupLocalService);
+		messageResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		messageResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		messageResource.setRoleLocalService(_roleLocalService);
+		messageResource.setSortParserProvider(_sortParserProvider);
+
+		try {
+			return method.invoke(messageResource, arguments);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			throw invocationTargetException.getTargetException();
+		}
+		finally {
+			_componentServiceObjects.ungetService(messageResource);
+
+			PrincipalThreadLocal.setName(name);
+
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+		}
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<MessageResource> _componentServiceObjects;
+
+	@Reference
+	private PermissionCheckerFactory _defaultPermissionCheckerFactory;
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private SortParserProvider _sortParserProvider;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private static class ResourceProxyProviderFunctionHolder {
+
+		private static final Function<InvocationHandler, MessageResource>
+			_messageResourceProxyProviderFunction = _getProxyProviderFunction();
+
+	}
+
+	private class AcceptLanguageImpl implements AcceptLanguage {
+
+		public AcceptLanguageImpl(
+			HttpServletRequest httpServletRequest, Locale preferredLocale,
+			User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_preferredLocale = preferredLocale;
+			_user = user;
+		}
+
+		@Override
+		public List<Locale> getLocales() {
+			return Arrays.asList(getPreferredLocale());
+		}
+
+		@Override
+		public String getPreferredLanguageId() {
+			return LocaleUtil.toLanguageId(getPreferredLocale());
+		}
+
+		@Override
+		public Locale getPreferredLocale() {
+			if (_preferredLocale != null) {
+				return _preferredLocale;
+			}
+
+			if (_httpServletRequest != null) {
+				Locale locale = (Locale)_httpServletRequest.getAttribute(
+					WebKeys.LOCALE);
+
+				if (locale != null) {
+					return locale;
+				}
+			}
+
+			return _user.getLocale();
+		}
+
+		@Override
+		public boolean isAcceptAllLanguages() {
+			return false;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final Locale _preferredLocale;
+		private final User _user;
+
+	}
+
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/src/main/java/com/liferay/graphql/bug/rest/internal/security/permission/LiberalPermissionChecker.java
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/src/main/java/com/liferay/graphql/bug/rest/internal/security/permission/LiberalPermissionChecker.java
@@ -1,0 +1,221 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.graphql.bug.rest.internal.security.permission;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.RoleConstants;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.UserBag;
+import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+public class LiberalPermissionChecker implements PermissionChecker {
+
+	public LiberalPermissionChecker(User user) {
+		init(user);
+	}
+
+	@Override
+	public PermissionChecker clone() {
+		return this;
+	}
+
+	@Override
+	public long getCompanyId() {
+		return _user.getCompanyId();
+	}
+
+	@Override
+	public long[] getGuestUserRoleIds() {
+		return PermissionChecker.DEFAULT_ROLE_IDS;
+	}
+
+	/**
+	 * @deprecated As of Judson (7.1.x), with no direct replacement
+	 */
+	@Deprecated
+	public List<Long> getOwnerResourceBlockIds(
+		long companyId, long groupId, String name, String actionId) {
+
+		return new ArrayList<>();
+	}
+
+	@Override
+	public long getOwnerRoleId() {
+		return _ownerRole.getRoleId();
+	}
+
+	@Override
+	public Map<Object, Object> getPermissionChecksMap() {
+		return new HashMap<>();
+	}
+
+	/**
+	 * @deprecated As of Judson (7.1.x), with no direct replacement
+	 */
+	@Deprecated
+	public List<Long> getResourceBlockIds(
+		long companyId, long groupId, long userId, String name,
+		String actionId) {
+
+		return new ArrayList<>();
+	}
+
+	@Override
+	public long[] getRoleIds(long userId, long groupId) {
+		return PermissionChecker.DEFAULT_ROLE_IDS;
+	}
+
+	@Override
+	public User getUser() {
+		return _user;
+	}
+
+	@Override
+	public UserBag getUserBag() {
+		return null;
+	}
+
+	@Override
+	public long getUserId() {
+		return _user.getUserId();
+	}
+
+	@Override
+	public boolean hasOwnerPermission(
+		long companyId, String name, long primKey, long ownerId,
+		String actionId) {
+
+		return true;
+	}
+
+	@Override
+	public boolean hasOwnerPermission(
+		long companyId, String name, String primKey, long ownerId,
+		String actionId) {
+
+		return true;
+	}
+
+	@Override
+	public boolean hasPermission(
+		Group group, String name, long primKey, String actionId) {
+
+		return true;
+	}
+
+	@Override
+	public boolean hasPermission(
+		Group group, String name, String primKey, String actionId) {
+
+		return true;
+	}
+
+	@Override
+	public boolean hasPermission(
+		long groupId, String name, long primKey, String actionId) {
+
+		return true;
+	}
+
+	@Override
+	public boolean hasPermission(
+		long groupId, String name, String primKey, String actionId) {
+
+		return true;
+	}
+
+	@Override
+	public void init(User user) {
+		_user = user;
+
+		try {
+			_ownerRole = RoleLocalServiceUtil.getRole(
+				user.getCompanyId(), RoleConstants.OWNER);
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+		}
+	}
+
+	@Override
+	public boolean isCheckGuest() {
+		return GetterUtil.getBoolean(
+			PropsUtil.get(PropsKeys.PERMISSIONS_CHECK_GUEST_ENABLED));
+	}
+
+	@Override
+	public boolean isCompanyAdmin() {
+		return true;
+	}
+
+	@Override
+	public boolean isCompanyAdmin(long companyId) {
+		return true;
+	}
+
+	@Override
+	public boolean isContentReviewer(long companyId, long groupId) {
+		return true;
+	}
+
+	@Override
+	public boolean isGroupAdmin(long groupId) {
+		return true;
+	}
+
+	@Override
+	public boolean isGroupMember(long groupId) {
+		return true;
+	}
+
+	@Override
+	public boolean isGroupOwner(long groupId) {
+		return true;
+	}
+
+	@Override
+	public boolean isOmniadmin() {
+		return true;
+	}
+
+	@Override
+	public boolean isOrganizationAdmin(long organizationId) {
+		return true;
+	}
+
+	@Override
+	public boolean isOrganizationOwner(long organizationId) {
+		return true;
+	}
+
+	@Override
+	public boolean isSignedIn() {
+		return true;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		LiberalPermissionChecker.class);
+
+	private Role _ownerRole;
+	private User _user;
+
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/message.properties
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/message.properties
@@ -1,0 +1,12 @@
+#
+# This is a generated file.
+#
+
+api.version=v1.0
+batch.engine.entity.class.name=com.liferay.graphql.bug.rest.dto.v1_0.Message
+batch.engine.task.item.delegate=true
+batch.planner.export.enabled=true
+batch.planner.import.enabled=false
+entity.class.name=com.liferay.graphql.bug.rest.dto.v1_0.Message
+osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Bug.REST)
+osgi.jaxrs.resource=true

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/openapi.properties
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/openapi.properties
@@ -1,0 +1,9 @@
+#
+# This is a generated file.
+#
+
+api.version=v1.0
+openapi.resource=true
+openapi.resource.path=/headless-bug
+osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Bug.REST)
+osgi.jaxrs.resource=true

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-test/bnd.bnd
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Graphql Bug REST TEST
+Bundle-SymbolicName: com.liferay.graphql.bug.rest.test
+Bundle-Version: 1.0.0

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-test/build.gradle
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-test/build.gradle
@@ -1,0 +1,13 @@
+dependencies {
+	testIntegrationImplementation group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.16.1"
+	testIntegrationImplementation group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.16.1"
+	testIntegrationImplementation group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.16.1"
+	testIntegrationImplementation group: "javax.annotation", name: "javax.annotation-api", version: "1.3.2"
+	testIntegrationImplementation group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
+	testIntegrationImplementation project(":apps:portal-language:portal-language-override-api")
+	testIntegrationImplementation project(":apps:portal-language:portal-language-rest-api")
+	testIntegrationImplementation project(":apps:portal-language:portal-language-rest-client")
+	testIntegrationImplementation project(":apps:portal-odata:portal-odata-api")
+	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
+	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-test/src/testIntegration/java/com/liferay/graphql/bug/rest/resource/v1_0/test/BaseMessageResourceTestCase.java
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-test/src/testIntegration/java/com/liferay/graphql/bug/rest/resource/v1_0/test/BaseMessageResourceTestCase.java
@@ -1,0 +1,963 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.graphql.bug.rest.resource.v1_0.test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
+import com.liferay.graphql.bug.rest.client.dto.v1_0.Message;
+import com.liferay.graphql.bug.rest.client.http.HttpInvoker;
+import com.liferay.graphql.bug.rest.client.pagination.Page;
+import com.liferay.graphql.bug.rest.client.resource.v1_0.MessageResource;
+import com.liferay.graphql.bug.rest.client.serdes.v1_0.MessageSerDes;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import java.lang.reflect.Method;
+
+import java.text.DateFormat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Thiago Buarque
+ * @generated
+ */
+@Generated("")
+public abstract class BaseMessageResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		irrelevantGroup = GroupTestUtil.addGroup();
+		testGroup = GroupTestUtil.addGroup();
+
+		testCompany = CompanyLocalServiceUtil.getCompany(
+			testGroup.getCompanyId());
+
+		_messageResource.setContextCompany(testCompany);
+
+		MessageResource.Builder builder = MessageResource.builder();
+
+		messageResource = builder.authentication(
+			"test@liferay.com", PropsValues.DEFAULT_ADMIN_PASSWORD
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GroupTestUtil.deleteGroup(irrelevantGroup);
+		GroupTestUtil.deleteGroup(testGroup);
+	}
+
+	@Test
+	public void testClientSerDesToDTO() throws Exception {
+		ObjectMapper objectMapper = new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				enable(SerializationFeature.INDENT_OUTPUT);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+
+		Message message1 = randomMessage();
+
+		String json = objectMapper.writeValueAsString(message1);
+
+		Message message2 = MessageSerDes.toDTO(json);
+
+		Assert.assertTrue(equals(message1, message2));
+	}
+
+	@Test
+	public void testClientSerDesToJSON() throws Exception {
+		ObjectMapper objectMapper = new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+
+		Message message = randomMessage();
+
+		String json1 = objectMapper.writeValueAsString(message);
+		String json2 = MessageSerDes.toJSON(message);
+
+		Assert.assertEquals(
+			objectMapper.readTree(json1), objectMapper.readTree(json2));
+	}
+
+	@Test
+	public void testEscapeRegexInStringFields() throws Exception {
+		String regex = "^[0-9]+(\\.[0-9]{1,2})\"?";
+
+		Message message = randomMessage();
+
+		message.setKey(regex);
+		message.setLanguageId(regex);
+		message.setValue(regex);
+
+		String json = MessageSerDes.toJSON(message);
+
+		Assert.assertFalse(json.contains(regex));
+
+		message = MessageSerDes.toDTO(json);
+
+		Assert.assertEquals(regex, message.getKey());
+		Assert.assertEquals(regex, message.getLanguageId());
+		Assert.assertEquals(regex, message.getValue());
+	}
+
+	@Test
+	public void testGetMessagesPage() throws Exception {
+		Page<Message> page = messageResource.getMessagesPage(null);
+
+		long totalCount = page.getTotalCount();
+
+		Message message1 = testGetMessagesPage_addMessage(randomMessage());
+
+		Message message2 = testGetMessagesPage_addMessage(randomMessage());
+
+		page = messageResource.getMessagesPage(null);
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(message1, (List<Message>)page.getItems());
+		assertContains(message2, (List<Message>)page.getItems());
+		assertValid(page, testGetMessagesPage_getExpectedActions());
+	}
+
+	protected Map<String, Map<String, String>>
+			testGetMessagesPage_getExpectedActions()
+		throws Exception {
+
+		Map<String, Map<String, String>> expectedActions = new HashMap<>();
+
+		return expectedActions;
+	}
+
+	protected Message testGetMessagesPage_addMessage(Message message)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGraphQLGetMessagesPage() throws Exception {
+		Assert.assertTrue(false);
+	}
+
+	protected void assertContains(Message message, List<Message> messages) {
+		boolean contains = false;
+
+		for (Message item : messages) {
+			if (equals(message, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(messages + " does not contain " + message, contains);
+	}
+
+	protected void assertHttpResponseStatusCode(
+		int expectedHttpResponseStatusCode,
+		HttpInvoker.HttpResponse actualHttpResponse) {
+
+		Assert.assertEquals(
+			expectedHttpResponseStatusCode, actualHttpResponse.getStatusCode());
+	}
+
+	protected void assertEquals(Message message1, Message message2) {
+		Assert.assertTrue(
+			message1 + " does not equal " + message2,
+			equals(message1, message2));
+	}
+
+	protected void assertEquals(
+		List<Message> messages1, List<Message> messages2) {
+
+		Assert.assertEquals(messages1.size(), messages2.size());
+
+		for (int i = 0; i < messages1.size(); i++) {
+			Message message1 = messages1.get(i);
+			Message message2 = messages2.get(i);
+
+			assertEquals(message1, message2);
+		}
+	}
+
+	protected void assertEqualsIgnoringOrder(
+		List<Message> messages1, List<Message> messages2) {
+
+		Assert.assertEquals(messages1.size(), messages2.size());
+
+		for (Message message1 : messages1) {
+			boolean contains = false;
+
+			for (Message message2 : messages2) {
+				if (equals(message1, message2)) {
+					contains = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(
+				messages2 + " does not contain " + message1, contains);
+		}
+	}
+
+	protected void assertValid(Message message) throws Exception {
+		boolean valid = true;
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("key", additionalAssertFieldName)) {
+				if (message.getKey() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("languageId", additionalAssertFieldName)) {
+				if (message.getLanguageId() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("value", additionalAssertFieldName)) {
+				if (message.getValue() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected void assertValid(Page<Message> page) {
+		assertValid(page, Collections.emptyMap());
+	}
+
+	protected void assertValid(
+		Page<Message> page, Map<String, Map<String, String>> expectedActions) {
+
+		boolean valid = false;
+
+		java.util.Collection<Message> messages = page.getItems();
+
+		int size = messages.size();
+
+		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
+			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
+			(size > 0)) {
+
+			valid = true;
+		}
+
+		Assert.assertTrue(valid);
+
+		assertValid(page.getActions(), expectedActions);
+	}
+
+	protected void assertValid(
+		Map<String, Map<String, String>> actions1,
+		Map<String, Map<String, String>> actions2) {
+
+		for (String key : actions2.keySet()) {
+			Map action = actions1.get(key);
+
+			Assert.assertNotNull(key + " does not contain an action", action);
+
+			Map<String, String> expectedAction = actions2.get(key);
+
+			Assert.assertEquals(
+				expectedAction.get("method"), action.get("method"));
+			Assert.assertEquals(expectedAction.get("href"), action.get("href"));
+		}
+	}
+
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[0];
+	}
+
+	protected List<GraphQLField> getGraphQLFields() throws Exception {
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field :
+				getDeclaredFields(
+					com.liferay.graphql.bug.rest.dto.v1_0.Message.class)) {
+
+			if (!ArrayUtil.contains(
+					getAdditionalAssertFieldNames(), field.getName())) {
+
+				continue;
+			}
+
+			graphQLFields.addAll(getGraphQLFields(field));
+		}
+
+		return graphQLFields;
+	}
+
+	protected List<GraphQLField> getGraphQLFields(
+			java.lang.reflect.Field... fields)
+		throws Exception {
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field : fields) {
+			com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+				vulcanGraphQLField = field.getAnnotation(
+					com.liferay.portal.vulcan.graphql.annotation.GraphQLField.
+						class);
+
+			if (vulcanGraphQLField != null) {
+				Class<?> clazz = field.getType();
+
+				if (clazz.isArray()) {
+					clazz = clazz.getComponentType();
+				}
+
+				List<GraphQLField> childrenGraphQLFields = getGraphQLFields(
+					getDeclaredFields(clazz));
+
+				graphQLFields.add(
+					new GraphQLField(field.getName(), childrenGraphQLFields));
+			}
+		}
+
+		return graphQLFields;
+	}
+
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[0];
+	}
+
+	protected boolean equals(Message message1, Message message2) {
+		if (message1 == message2) {
+			return true;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("key", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(message1.getKey(), message2.getKey())) {
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("languageId", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						message1.getLanguageId(), message2.getLanguageId())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("value", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						message1.getValue(), message2.getValue())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		return true;
+	}
+
+	protected boolean equals(
+		Map<String, Object> map1, Map<String, Object> map2) {
+
+		if (Objects.equals(map1.keySet(), map2.keySet())) {
+			for (Map.Entry<String, Object> entry : map1.entrySet()) {
+				if (entry.getValue() instanceof Map) {
+					if (!equals(
+							(Map)entry.getValue(),
+							(Map)map2.get(entry.getKey()))) {
+
+						return false;
+					}
+				}
+				else if (!Objects.deepEquals(
+							entry.getValue(), map2.get(entry.getKey()))) {
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	protected java.lang.reflect.Field[] getDeclaredFields(Class clazz)
+		throws Exception {
+
+		if (clazz.getClassLoader() == null) {
+			return new java.lang.reflect.Field[0];
+		}
+
+		return TransformUtil.transform(
+			ReflectionUtil.getDeclaredFields(clazz),
+			field -> {
+				if (field.isSynthetic()) {
+					return null;
+				}
+
+				return field;
+			},
+			java.lang.reflect.Field.class);
+	}
+
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
+		if (!(_messageResource instanceof EntityModelResource)) {
+			throw new UnsupportedOperationException(
+				"Resource is not an instance of EntityModelResource");
+		}
+
+		EntityModelResource entityModelResource =
+			(EntityModelResource)_messageResource;
+
+		EntityModel entityModel = entityModelResource.getEntityModel(
+			new MultivaluedHashMap());
+
+		if (entityModel == null) {
+			return Collections.emptyList();
+		}
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		return entityFieldsMap.values();
+	}
+
+	protected List<EntityField> getEntityFields(EntityField.Type type)
+		throws Exception {
+
+		return TransformUtil.transform(
+			getEntityFields(),
+			entityField -> {
+				if (!Objects.equals(entityField.getType(), type) ||
+					ArrayUtil.contains(
+						getIgnoredEntityFieldNames(), entityField.getName())) {
+
+					return null;
+				}
+
+				return entityField;
+			});
+	}
+
+	protected String getFilterString(
+		EntityField entityField, String operator, Message message) {
+
+		StringBundler sb = new StringBundler();
+
+		String entityFieldName = entityField.getName();
+
+		sb.append(entityFieldName);
+
+		sb.append(" ");
+		sb.append(operator);
+		sb.append(" ");
+
+		if (entityFieldName.equals("key")) {
+			Object object = message.getKey();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("languageId")) {
+			Object object = message.getLanguageId();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("value")) {
+			Object object = message.getValue();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid entity field " + entityFieldName);
+	}
+
+	protected String invoke(String query) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(
+			JSONUtil.put(
+				"query", query
+			).toString(),
+			"application/json");
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+		httpInvoker.path("http://localhost:8080/o/graphql");
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		return httpResponse.getContent();
+	}
+
+	protected JSONObject invokeGraphQLMutation(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField mutationGraphQLField = new GraphQLField(
+			"mutation", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(mutationGraphQLField.toString()));
+	}
+
+	protected JSONObject invokeGraphQLQuery(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField queryGraphQLField = new GraphQLField(
+			"query", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(queryGraphQLField.toString()));
+	}
+
+	protected Message randomMessage() throws Exception {
+		return new Message() {
+			{
+				key = StringUtil.toLowerCase(RandomTestUtil.randomString());
+				languageId = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				value = StringUtil.toLowerCase(RandomTestUtil.randomString());
+			}
+		};
+	}
+
+	protected Message randomIrrelevantMessage() throws Exception {
+		Message randomIrrelevantMessage = randomMessage();
+
+		return randomIrrelevantMessage;
+	}
+
+	protected Message randomPatchMessage() throws Exception {
+		return randomMessage();
+	}
+
+	protected MessageResource messageResource;
+	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected com.liferay.portal.kernel.model.Company testCompany;
+	protected com.liferay.portal.kernel.model.Group testGroup;
+
+	protected static class BeanTestUtil {
+
+		public static void copyProperties(Object source, Object target)
+			throws Exception {
+
+			Class<?> sourceClass = _getSuperClass(source.getClass());
+
+			Class<?> targetClass = target.getClass();
+
+			for (java.lang.reflect.Field field :
+					sourceClass.getDeclaredFields()) {
+
+				if (field.isSynthetic()) {
+					continue;
+				}
+
+				Method getMethod = _getMethod(
+					sourceClass, field.getName(), "get");
+
+				Method setMethod = _getMethod(
+					targetClass, field.getName(), "set",
+					getMethod.getReturnType());
+
+				setMethod.invoke(target, getMethod.invoke(source));
+			}
+		}
+
+		public static boolean hasProperty(Object bean, String name) {
+			Method setMethod = _getMethod(
+				bean.getClass(), "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod != null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		public static void setProperty(Object bean, String name, Object value)
+			throws Exception {
+
+			Class<?> clazz = bean.getClass();
+
+			Method setMethod = _getMethod(
+				clazz, "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod == null) {
+				throw new NoSuchMethodException();
+			}
+
+			Class<?>[] parameterTypes = setMethod.getParameterTypes();
+
+			setMethod.invoke(bean, _translateValue(parameterTypes[0], value));
+		}
+
+		private static Method _getMethod(Class<?> clazz, String name) {
+			for (Method method : clazz.getMethods()) {
+				if (name.equals(method.getName()) &&
+					(method.getParameterCount() == 1) &&
+					_parameterTypes.contains(method.getParameterTypes()[0])) {
+
+					return method;
+				}
+			}
+
+			return null;
+		}
+
+		private static Method _getMethod(
+				Class<?> clazz, String fieldName, String prefix,
+				Class<?>... parameterTypes)
+			throws Exception {
+
+			return clazz.getMethod(
+				prefix + StringUtil.upperCaseFirstLetter(fieldName),
+				parameterTypes);
+		}
+
+		private static Class<?> _getSuperClass(Class<?> clazz) {
+			Class<?> superClass = clazz.getSuperclass();
+
+			if ((superClass == null) || (superClass == Object.class)) {
+				return clazz;
+			}
+
+			return superClass;
+		}
+
+		private static Object _translateValue(
+			Class<?> parameterType, Object value) {
+
+			if ((value instanceof Integer) &&
+				parameterType.equals(Long.class)) {
+
+				Integer intValue = (Integer)value;
+
+				return intValue.longValue();
+			}
+
+			return value;
+		}
+
+		private static final Set<Class<?>> _parameterTypes = new HashSet<>(
+			Arrays.asList(
+				Boolean.class, Date.class, Double.class, Integer.class,
+				Long.class, Map.class, String.class));
+
+	}
+
+	protected class GraphQLField {
+
+		public GraphQLField(String key, GraphQLField... graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(String key, List<GraphQLField> graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			GraphQLField... graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = Arrays.asList(graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			List<GraphQLField> graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = graphQLFields;
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder(_key);
+
+			if (!_parameterMap.isEmpty()) {
+				sb.append("(");
+
+				for (Map.Entry<String, Object> entry :
+						_parameterMap.entrySet()) {
+
+					sb.append(entry.getKey());
+					sb.append(": ");
+					sb.append(entry.getValue());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append(")");
+			}
+
+			if (!_graphQLFields.isEmpty()) {
+				sb.append("{");
+
+				for (GraphQLField graphQLField : _graphQLFields) {
+					sb.append(graphQLField.toString());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append("}");
+			}
+
+			return sb.toString();
+		}
+
+		private final List<GraphQLField> _graphQLFields;
+		private final String _key;
+		private final Map<String, Object> _parameterMap;
+
+	}
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseMessageResourceTestCase.class);
+
+	private static DateFormat _dateFormat;
+
+	@Inject
+	private com.liferay.graphql.bug.rest.resource.v1_0.MessageResource
+		_messageResource;
+
+}

--- a/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-test/src/testIntegration/java/com/liferay/graphql/bug/rest/resource/v1_0/test/MessageResourceTest.java
+++ b/modules/apps/headless-graphql-bug/headless-graphql-bug-rest-test/src/testIntegration/java/com/liferay/graphql/bug/rest/resource/v1_0/test/MessageResourceTest.java
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.graphql.bug.rest.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Thiago Buarque
+ */
+@Ignore
+@RunWith(Arquillian.class)
+public class MessageResourceTest extends BaseMessageResourceTestCase {
+}


### PR DESCRIPTION
We can't have a GraphQL query which receives a array as parameter.

For instance the query below fails:
```graphql
{
  messages(keys: []) {
    items {
      key
      languageId
      value
    }
    page
    pageSize
    totalCount
  }
}
```
It throws
```json
{
  "errors": [
    {
      "message": "Exception while fetching data (/messages) : argument type mismatch",
      "locations": [],
      "extensions": {
        "exception": {
          "errno": 500
        },
        "code": "Internal Server Error",
        "classification": "DataFetchingException"
      }
    }
  ],
  "data": {
    "messages": null
  }
}
```

But passes if the parameter is null
```graphql
{
  messages(keys: null) {
    items {
      key
      languageId
      value
    }
    page
    pageSize
    totalCount
  }
}
```

That's why the Query method generated inside the /graph/query.v1_0/Query.java is generated receiving an array of String[]

```java
@GraphQLField
public MessagePage messages(@GraphQLName("keys") String[] keys)
	throws Exception {

	return _applyComponentServiceObjects(
		_messageResourceComponentServiceObjects,
		this::_populateResourceContext,
		messageResource -> new MessagePage(
			messageResource.getMessagesPage(keys)));
}
```

But when that method is invoked [here](https://github.com/liferay/liferay-portal/blob/98578f788c07f813ba8db42d5e0ae9c63837db21/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/data/processor/LiferayMethodDataFetchingProcessor.java#L309), the type is an `ArrayList<String>`