### PR TITLE
LPD-90081 Point jira-task output at /start-work for development setup

### DIFF
--- a/.claude/skills/jira-task/SKILL.md
+++ b/.claude/skills/jira-task/SKILL.md
@@ -42,4 +42,6 @@ Create the issue in the LPD project with the gathered summary, description, and 
 
 ## Output
 
-Return the ticket key and the browse URL: `https://liferay.atlassian.net/browse/<KEY>`.
+Return the parent task key and the browse URL: `https://liferay.atlassian.net/browse/<KEY>`.
+
+The parent task is enough on its own. Jira does not autocreate the Technical Task subtask until the parent transitions to an in-progress status, and that subtask is only relevant once development starts (branch naming, commit prefixes, PR title). When the user is going to begin work on the ticket, point them to the `start-work` skill, which transitions the parent, resolves the subtask, assigns both, and creates the branch.


### PR DESCRIPTION
## Summary

- Update the `jira-task` skill so its output points users at the `start-work` skill when they are about to begin development on the new ticket.

Jira: [LPD-90081](https://liferay.atlassian.net/browse/LPD-90081) (subtask of [LPD-90080](https://liferay.atlassian.net/browse/LPD-90080))

## Test plan

- [x] Read `jira-task/SKILL.md` end-to-end after the change; output section still produces a parent key + URL and now also names `start-work` as the next step.
- [x] Cross-checked against `start-work/SKILL.md` to confirm it owns the subtask resolution / assignment / branch creation steps that this draft tried to move into `jira-task`.