### PR TITLE
LPD-91042 Add format-source rule for REST test override convention

### DIFF
--- a/.claude/skills/format-source/SKILL.md
+++ b/.claude/skills/format-source/SKILL.md
@@ -1000,3 +1000,39 @@ The same applies when renaming a method or its parameter to match the vocabulary
 ```
 
 When you rename a local, propagate the new name to every call site, every parameter that passes it on, and every private helper that receives it.
+
+### Rule 48: REST Integration Tests Override, Never Add
+
+**Why:** `Base*ResourceTestCase` defines the test contract; subclass methods must override inherited ones so every assertion lives under one canonical name and the base `setUp`/`tearDown` chain always runs.
+
+**Examples:**
+
+Every `@Test`, `@Before`, and `@After` in a `*ResourceTest` overrides an inherited method. In `tearDown`, call `super.tearDown()` first.
+
+```diff
+-@After
+-public void tearDownFoos() throws Exception {
++@After
++@Override
++public void tearDown() throws Exception {
++	super.tearDown();
++
+ 	_fooLocalService.deleteFoo(_foo);
+ }
+
+-@Test
+-public void testGetFooEdgeCase() throws Exception {
+-	// new public test introduced in the subclass
+-}
+```
+
+Extra logic goes into a private `_test*` helper whose name extends the overridden test with a suffix describing the variation (`With`, `In`, `When`, `For`, and similar are all fine — whatever reads naturally).
+
+```diff
+ @Override
+ @Test
+ public void testGetFoo() throws Exception {
++	_testGetFooWithBar(input -> resource.getFoo(input));
++	_testGetFooWhenQuxIsNull(input -> resource.getFoo(input));
+ }
+```


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91042

## What is being fixed

The format-source skill encodes Liferay's manual coding conventions as rules, but it did not yet capture the override-only convention for REST integration tests. Subclasses of `Base*ResourceTestCase` must not introduce new public `@Test`, `@Before`, or `@After` methods, must override `tearDown` with `super.tearDown()` called first, and must fold extra logic into private `_test*` helpers whose names extend the overridden test with a descriptive suffix.

## How it is being fixed

Rule 48 is appended to `.claude/skills/format-source/SKILL.md`. It states the rule in a single **Why** sentence and shows two diff blocks: one replacing a custom-named `@After` with an overridden `tearDown` (and dropping a new public `@Test`), and one delegating variations to private `_test*` helpers with descriptive suffixes (`With`, `In`, `When`, `For`, and similar).

## Why are there no tests?

Markdown-only change to a Claude Code skill definition; no production code is affected.