### PR TITLE
LPD-91109 Fix swapped component IDs in jira-task and jira-bug

### DIFF
--- a/.claude/skills/jira-bug/SKILL.md
+++ b/.claude/skills/jira-bug/SKILL.md
@@ -30,8 +30,8 @@ The LPD project requires the following fields. Apply these defaults unless the u
 
 - **Affects Version**: `Master` (ID: `16660`).
 - **Component**: Select from the list below, or infer from the code area. Common components include:
-	- `Content Publishing > Resource Importer` (ID: `15805`)
-	- `Data Integration > Export/Import` (ID: `16131`)
+	- `Content Publishing > Resource Importer` (ID: `16131`)
+	- `Data Integration > Export/Import` (ID: `15805`)
 	- `Headless Batch Engine API` (ID: `16022`)
 - **Cross Cutting Properties** (`customfield_10979`): `None` (ID: `14468`).
 

--- a/.claude/skills/jira-task/SKILL.md
+++ b/.claude/skills/jira-task/SKILL.md
@@ -27,8 +27,8 @@ Request any missing details from the user:
 The LPD project requires the following fields. Apply these defaults unless the user specifies otherwise:
 
 - **Component**: Select from the list below, or infer from the code area. Common components include:
-	- `Content Publishing > Resource Importer` (ID: `15805`)
-	- `Data Integration > Export/Import` (ID: `16131`)
+	- `Content Publishing > Resource Importer` (ID: `16131`)
+	- `Data Integration > Export/Import` (ID: `15805`)
 	- `Headless Batch Engine API` (ID: `16022`)
 - **Issue Type**: `Task` (ID: `10002`).
 


### PR DESCRIPTION
## Summary

The component ID table copied across `.claude/skills/jira-task/SKILL.md` and `.claude/skills/jira-bug/SKILL.md` had `Content Publishing > Resource Importer` (real ID `16131`) and `Data Integration > Export/Import` (real ID `15805`) swapped. Tickets created via either skill landed in the wrong component until corrected by hand. This swaps them back.

## Evidence

Both component IDs queried directly against `liferay.atlassian.net/rest/api/3/component/{id}`:

`GET /rest/api/3/component/15805`
```json
  {
      "id": "15805",
      "name": "Data Integration > Export/Import",
      "description": "Exporting or importing multiple pages, templates and themes, using a single LAR (Liferay Archive) file.",
      "project": "LPD"
  }
  ```



`GET /rest/api/3/component/16131`
  ```json
  {
      "id": "16131",
      "name": "Content Publishing > Resource Importer",
      "description": "The Resource Importer is a tool used to import various types of resources into Liferay, such as documents, images, and web content.",
      "project": "LPD"
  }
```

## Test plan

Verified each ID against `GET /rest/api/3/component/{id}` on `liferay.atlassian.net`.

## Ticket

https://liferay.atlassian.net/browse/LPD-91109 (parent: LPD-91108)