### PR TITLE
LRDOCS-17027 .claude: derive worktree path prefix from main worktree basename

### DIFF
--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -67,9 +67,11 @@ function _create_worktree {
 	cwd="$(jq --exit-status --raw-output ".cwd" <<< "${input}")" || _die "The cwd field is missing from the hook input ${input}."
 	name="$(jq --exit-status --raw-output ".name" <<< "${input}")" || _die "The name field is missing from the hook input ${input}."
 
-	local target_path
+	local main_worktree target_path
 
-	target_path="$(dirname "$(git -C "${cwd}" rev-parse --show-toplevel)")/liferay-portal-${name}"
+	main_worktree="$(git -C "${cwd}" worktree list --porcelain | grep --extended-regexp "^worktree " | head --lines=1 | sed "s/^worktree //")"
+
+	target_path="$(dirname "${main_worktree}")/$(basename "${main_worktree}")-${name}"
 
 	if ! git -C "${cwd}" worktree list --porcelain | grep --fixed-strings --line-regexp --quiet "worktree ${target_path}"
 	then


### PR DESCRIPTION
Jira: [LRDOCS-17027](https://liferay.atlassian.net/browse/LRDOCS-17027)

## Summary

Replace the hardcoded `liferay-portal-${name}` prefix in `_create_worktree` with the basename of the main worktree (resolved via `git worktree list --porcelain | head`). Lets other Liferay repos reuse the same hook for worktree creation without needing a fork of the script.

## Why

The docs team is interested in invoking this hook from `liferay-learn` with `LIFERAY_PROVISION=none` to skip the portal-specific bundle/DB/Tomcat provisioning while still getting standardized worktree creation. Today the hardcoded prefix would land a `liferay-learn` worktree at `~/projects/liferay-portal-<branch>` — wrong directory name and a potential collision with real portal worktrees.

With this change:

- Invoked from `liferay-portal` → `~/projects/liferay-portal-<branch>` (byte-identical to current behavior)
- Invoked from `liferay-learn` → `~/projects/liferay-learn-<branch>` (correct)

## Behavior preservation for portal

The LPD-88020 invariant — siblings of the repo no matter where invoked — is preserved. `git worktree list --porcelain` lists the main worktree first regardless of which checkout the script is invoked from, so the resolved path is stable across main checkout, subdirectory, and worktree cwds.

Smoke tested locally across 7 cwd scenarios (portal main / subdir / two worktrees; learn main / subdir / worktree):

| Caller cwd | Resolved target_path |
| :--- | :--- |
| `~/projects/liferay-portal` | `~/projects/liferay-portal-<name>` |
| `~/projects/liferay-portal/modules` | `~/projects/liferay-portal-<name>` |
| `~/projects/liferay-portal-mermaid` (worktree) | `~/projects/liferay-portal-<name>` |
| `~/projects/liferay-learn` | `~/projects/liferay-learn-<name>` |
| `~/projects/liferay-learn/docs` | `~/projects/liferay-learn-<name>` |
| `~/projects/liferay-learn-LRDOCS-16250` (worktree) | `~/projects/liferay-learn-<name>` |

All portal cases produce the same path they do today.

## Out of scope

`_resolve_main_worktree_dir` still uses a literal `liferay-portal` regex. It's only called from provisioning functions (`_reuse_worktree`, `_set_gradle_paths`, `_set_worktree_paths`) downstream of the `LIFERAY_PROVISION=none` gate, so a `liferay-learn` invocation never reaches it. Leaving that alone keeps the change minimal.

## Test plan

- [ ] Verify portal worktree creation continues to land at `~/projects/liferay-portal-<branch>` on a fresh `claude --worktree`
- [ ] Verify the full provisioning pipeline (bundle, DB, ports, Tomcat) still completes end-to-end for a portal invocation
- [ ] (Follow-up in `liferay-learn`) Wire up a `WorktreeCreate` hook that invokes this script with `LIFERAY_PROVISION=none` and confirm the worktree lands at `~/projects/liferay-learn-<branch>`
