### PR TITLE
Fix sed flag order so AJP backref works in _set_tomcat_ports

### DIFF
--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -407,12 +407,12 @@ function _set_tomcat_ports {
 	local target_https=$((8443 + OFFSET))
 
 	_sed_inplace \
+		--regexp-extended \
 		--expression "/<Server/s/port=\"[0-9]+\"/port=\"${target_shutdown}\"/" \
 		--expression "/protocol=\"HTTP\\/1\\.1\"/s/port=\"[0-9]+\"/port=\"${target_http}\"/" \
 		--expression "/protocol=\"org\\.apache\\.coyote\\.http11\\.Http11NioProtocol\"/s/port=\"[0-9]+\"/port=\"${target_https}\"/" \
 		--expression "/<Connector protocol=\"AJP\\/1\\.3\"/,/\\/>/s/^([[:space:]]+)port=\"[0-9]+\"/\\1port=\"${target_ajp}\"/" \
 		--expression "s/redirectPort=\"[0-9]+\"/redirectPort=\"${target_https}\"/g" \
-		--regexp-extended \
 		"${file}"
 }
 


### PR DESCRIPTION
## Summary

`.claude/hooks/worktree-create.sh` is the hook that provisions a fresh worktree: it copies the bundle from the main worktree, picks a port offset, rewrites the config files that hold ports (Tomcat `server.xml`, OSGi configs, Gradle init, `portal-ext.properties`, `setenv.sh`, …) and finally starts Tomcat. One of those steps, `_set_tomcat_ports`, was failing on every fresh worktree, leaving it half-provisioned (bundle copied, offset claimed, most ports rewritten — but `server.xml` untouched and Tomcat never started).

The failing call was:

```bash
_sed_inplace \
    --expression "/<Server/s/port=\"[0-9]+\"/port=\"${target_shutdown}\"/" \
    --expression "/protocol=\"HTTP\/1\.1\"/s/port=\"[0-9]+\"/port=\"${target_http}\"/" \
    --expression "/protocol=\"org\.apache\.coyote\.http11\.Http11NioProtocol\"/s/port=\"[0-9]+\"/port=\"${target_https}\"/" \
    --expression "/<Connector protocol=\"AJP\/1\.3\"/,/\/>/s/^([[:space:]]+)port=\"[0-9]+\"/\1port=\"${target_ajp}\"/" \
    --expression "s/redirectPort=\"[0-9]+\"/redirectPort=\"${target_https}\"/g" \
    --regexp-extended \
    "${file}"
```

The fourth expression — the AJP block — uses a capture group `([[:space:]]+)` and the backreference `\1` in its replacement. Those constructs are only valid in extended regex mode. GNU `sed` does pass `--regexp-extended` as a global mode, but each `--expression` script is **compiled as the argument is parsed**, reading the flag in effect at that exact instant. With `--regexp-extended` placed **after** the `--expression` flags, all five scripts are compiled in BRE mode first, the AJP one then errors out because `\1` has no group to refer to, and `sed` aborts with:

```
sed: -e expression #4, char 84: invalid reference \1 on `s' command's RHS
```

`set -o errexit` then kills the hook before `server.xml` is rewritten or Tomcat is started.

## Fix

Move `--regexp-extended` to the line **before** the first `--expression`. That makes ERE active at compile time for all five expressions, the AJP capture group and backreference resolve, and the hook runs to completion.

## Test plan

- [x] Removed the bundle and re-ran the hook on a fresh worktree — `sed` no longer aborts, the hook reaches `catalina.sh jpda start`, and `<bundle>/tomcat-*/conf/server.xml` shows the offset applied: `<Server port="8005+N">`, HTTP `8080+N`, HTTPS `8443+N`, AJP `8009+N`.
- [x] Confirmed against a second fresh worktree with a different offset — same result, AJP port carries the offset (the line whose backreference used to fail).
- [x] `git diff` is a one-line move; no other behavior change.
