### PR TITLE
LPD-91707 Make worktree hooks work with BSD sed on macOS

### DIFF
--- a/.claude/hooks/_common.sh
+++ b/.claude/hooks/_common.sh
@@ -12,6 +12,40 @@ function _atomic_write {
 	mv "${file}.tmp" "${file}"
 }
 
+function _sed {
+	if [[ $(uname) == Darwin ]]
+	then
+		local args=()
+		local arg
+
+		for arg in "${@}"
+		do
+			case "${arg}" in
+				--expression)
+					args+=(-e)
+					;;
+				--regexp-extended)
+					args+=(-E)
+					;;
+				--in-place)
+					args+=(-i "")
+					;;
+				*)
+					args+=("${arg}")
+					;;
+			esac
+		done
+
+		sed "${args[@]}"
+	else
+		sed "${@}"
+	fi
+}
+
+function _sed_inplace {
+	_sed --in-place "${@}"
+}
+
 function _derive_db_name {
 	local dir_name="${1}"
 
@@ -26,7 +60,7 @@ function _derive_db_name {
 		return
 	fi
 
-	suffix="$(echo "${suffix}" | tr "[:upper:]" "[:lower:]" | sed --regexp-extended "s/[^a-z0-9]+/_/g; s/^_+|_+\$//g")"
+	suffix="$(echo "${suffix}" | tr "[:upper:]" "[:lower:]" | _sed --regexp-extended "s/[^a-z0-9]+/_/g; s/^_+|_+\$//g")"
 	suffix="${suffix:0:56}"
 
 	echo "lportal_${suffix}"
@@ -79,12 +113,12 @@ function _find_app_server_parent_dir {
 
 	if [[ -f ${user_props} ]]
 	then
-		raw="$(grep --extended-regexp "^[[:space:]]*app\.server\.parent\.dir=" "${user_props}" | tail --lines=1 | sed "s/^[[:space:]]*app\.server\.parent\.dir=//")"
+		raw="$(grep --extended-regexp "^[[:space:]]*app\.server\.parent\.dir=" "${user_props}" | tail --lines=1 | _sed "s/^[[:space:]]*app\.server\.parent\.dir=//")"
 	fi
 
 	if [[ -z ${raw} && -f ${default_props} ]]
 	then
-		raw="$(grep --extended-regexp "^[[:space:]]*app\.server\.parent\.dir=" "${default_props}" | tail --lines=1 | sed "s/^[[:space:]]*app\.server\.parent\.dir=//")"
+		raw="$(grep --extended-regexp "^[[:space:]]*app\.server\.parent\.dir=" "${default_props}" | tail --lines=1 | _sed "s/^[[:space:]]*app\.server\.parent\.dir=//")"
 	fi
 
 	[[ -n ${raw} ]] || return 1
@@ -123,7 +157,7 @@ function _get_property {
 
 	if [[ -f ${file} ]] && grep --extended-regexp --quiet "^[[:space:]]*${key}=" "${file}"
 	then
-		value="$(grep --extended-regexp "^[[:space:]]*${key}=" "${file}" | tail --lines=1 | sed --regexp-extended "s/^[[:space:]]*${key}=[[:space:]]*//; s/[[:space:]]+\$//")"
+		value="$(grep --extended-regexp "^[[:space:]]*${key}=" "${file}" | tail --lines=1 | _sed --regexp-extended "s/^[[:space:]]*${key}=[[:space:]]*//; s/[[:space:]]+\$//")"
 	fi
 
 	echo "${value}"

--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -89,7 +89,7 @@ function _resolve_main_worktree_dir {
 
 	repo_dir="$(git -C "${WORKTREE_DIR}" rev-parse --show-toplevel)"
 
-	git -C "${repo_dir}" worktree list --porcelain | grep --extended-regexp "^worktree .*/liferay-portal\$" | head --lines=1 | sed "s/^worktree //"
+	git -C "${repo_dir}" worktree list --porcelain | grep --extended-regexp "^worktree .*/liferay-portal\$" | head --lines=1 | _sed "s/^worktree //"
 }
 
 function _reuse_worktree {
@@ -131,15 +131,6 @@ function _reuse_worktree {
 		cp --archive "${main_bundles}/." "${BUNDLES_DIR}/"
 
 		_bundle_exists "${BUNDLES_DIR}" || _die "Bundle copy finished but no tomcat-* directory exists under ${BUNDLES_DIR}."
-	fi
-}
-
-function _sed_inplace {
-	if [[ $(uname) == Darwin ]]
-	then
-		sed -i "" "${@}"
-	else
-		sed --in-place "${@}"
 	fi
 }
 


### PR DESCRIPTION
## [LPD-91707](https://liferay.atlassian.net/browse/LPD-91707)

## Summary

The worktree provisioning hooks under `liferay-portal/.claude/hooks/` invoke `sed` with GNU long flags (`--expression`, `--regexp-extended`, `--in-place`) that BSD sed on macOS rejects with `sed: illegal option -- -`. 

On a fresh provision the hook completes `ant all` and then fails inside the post-bundle `_set_*` functions, leaving the worktree half-configured (port offset reserved, single config written, no `portal-ext.properties`, Tomcat ports unchanged, Catalina not started).

This PR introduces a `_sed` wrapper in `_common.sh` that translates the GNU long flags to BSD short forms on Darwin, routes every `sed` invocation through it, and collapses `_sed_inplace` into a thin alias for `_sed --in-place`.

