### PR TITLE
LPD-91810 Multiple improvements to worktree-create.sh

### DIFF
--- a/.claude/hooks/_common.sh
+++ b/.claude/hooks/_common.sh
@@ -15,21 +15,44 @@ function _atomic_write {
 function _derive_db_name {
 	local dir_name="${1}"
 
-	local suffix="${dir_name#liferay-portal}"
+	local slug
 
-	suffix="${suffix#-}"
+	slug="$(_derive_worktree_slug "${dir_name}")"
 
-	if [[ -z ${suffix} ]]
+	if [[ ${slug} == master ]]
 	then
 		echo lportal
 
 		return
 	fi
 
-	suffix="$(echo "${suffix}" | tr "[:upper:]" "[:lower:]" | sed --regexp-extended "s/[^a-z0-9]+/_/g; s/^_+|_+\$//g")"
+	echo "lportal_${slug//-/_}"
+}
+
+function _derive_es_index_prefix {
+	local dir_name="${1}"
+
+	echo "liferay-$(_derive_worktree_slug "${dir_name}")-"
+}
+
+function _derive_worktree_slug {
+	local dir_name="${1}"
+
+	local suffix="${dir_name#liferay-portal}"
+
+	suffix="${suffix#-}"
+
+	if [[ -z ${suffix} ]]
+	then
+		echo master
+
+		return
+	fi
+
+	suffix="$(echo "${suffix}" | tr "[:upper:]" "[:lower:]" | sed --regexp-extended "s/[^a-z0-9]+/-/g; s/^-+|-+\$//g")"
 	suffix="${suffix:0:56}"
 
-	echo "lportal_${suffix}"
+	echo "${suffix}"
 }
 
 function _die {

--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -565,7 +565,7 @@ function main {
 
 	if [[ ${LIFERAY_PROVISION:-} == fresh ]]
 	then
-		(cd "${WORKTREE_DIR}" && ANT_OPTS="-Xmx2560m" ant all >&2) || _die "ant all failed under ${WORKTREE_DIR}."
+		(cd "${WORKTREE_DIR}" && ANT_OPTS="-Xmx2560m" ant all > "${WORKTREE_DIR}/.worktree-ant-all.log" 2>&1) || _die "ant all failed under ${WORKTREE_DIR}. See ${WORKTREE_DIR}/.worktree-ant-all.log."
 	else
 		_reuse_worktree
 	fi

--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -262,7 +262,7 @@ function _set_elasticsearch_ports {
 
 	mkdir --parents "${configs_dir}"
 
-	local es_version=elasticsearch8
+	local es_version=
 
 	if [[ -f ${configs_dir}/com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config ]]
 	then
@@ -271,6 +271,42 @@ function _set_elasticsearch_ports {
 	then
 		es_version=elasticsearch8
 	fi
+
+	if [[ -z ${es_version} ]]
+	then
+		local branch
+
+		branch="$(git -C "${WORKTREE_DIR}" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+
+		if [[ ${branch} == master ]]
+		then
+			es_version=elasticsearch8
+		elif [[ ${branch} =~ ^release-([0-9]{4})\.q([1-4])$ ]]
+		then
+			local year="${BASH_REMATCH[1]}"
+			local quarter="${BASH_REMATCH[2]}"
+
+			if (( year > 2025 )) || (( year == 2025 && quarter >= 3 ))
+			then
+				es_version=elasticsearch8
+			else
+				es_version=elasticsearch7
+			fi
+		fi
+	fi
+
+	if [[ -z ${es_version} ]]
+	then
+		if [[ -d ${WORKTREE_DIR}/modules/apps/portal-search-elasticsearch7 ]]
+		then
+			es_version=elasticsearch7
+		elif [[ -d ${WORKTREE_DIR}/modules/apps/portal-search-elasticsearch8 ]]
+		then
+			es_version=elasticsearch8
+		fi
+	fi
+
+	es_version="${es_version:-elasticsearch8}"
 
 	local file="${configs_dir}/com.liferay.portal.search.${es_version}.configuration.ElasticsearchConfiguration.config"
 

--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -88,6 +88,13 @@ function _create_worktree {
 		fi
 	fi
 
+	if [[ ${LIFERAY_WORKTREE_REFRESH_BASE:-false} == true ]]
+	then
+		git -C "${cwd}" fetch --no-tags upstream master >&2
+
+		(cd "${target_path}" && git rebase upstream/master >&2) || _die "Failed to rebase ${name} onto upstream/master."
+	fi
+
 	WORKTREE_DIR="${target_path}"
 }
 

--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -39,7 +39,7 @@ function _collect_claimed_offsets {
 
 	repo_dir="$(git -C "${WORKTREE_DIR}" rev-parse --show-toplevel)"
 
-	local line worktree_path bundles offset_file
+	local line worktree_path offset_file
 
 	while IFS= read -r line
 	do
@@ -49,9 +49,16 @@ function _collect_claimed_offsets {
 
 		[[ ${worktree_path} != "${WORKTREE_DIR}" ]] || continue
 
-		bundles="$(_find_app_server_parent_dir "${worktree_path}" 2>/dev/null)" || continue
+		offset_file="${worktree_path}/.worktree-port-offset"
 
-		offset_file="${bundles}/.worktree-port-offset"
+		if [[ ! -f ${offset_file} ]]
+		then
+			local bundles
+
+			bundles="$(_find_app_server_parent_dir "${worktree_path}" 2>/dev/null)" || continue
+
+			offset_file="${bundles}/.worktree-port-offset"
+		fi
 
 		[[ -f ${offset_file} ]] || continue
 
@@ -368,11 +375,20 @@ EOF
 }
 
 function _set_port_offset {
-	local offset_file="${BUNDLES_DIR}/.worktree-port-offset"
+	local offset_file="${WORKTREE_DIR}/.worktree-port-offset"
+	local legacy_file="${BUNDLES_DIR}/.worktree-port-offset"
 
 	if [[ -f ${offset_file} ]]
 	then
 		OFFSET="$(cat "${offset_file}")"
+
+		return
+	fi
+
+	if [[ -f ${legacy_file} ]]
+	then
+		OFFSET="$(cat "${legacy_file}")"
+		echo "${OFFSET}" > "${offset_file}"
 
 		return
 	fi

--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -21,6 +21,87 @@ function _all_ports_free_for_offset {
 	return 0
 }
 
+function _bring_master_feature_flags {
+	[[ ${LIFERAY_BRING_MASTER_FLAGS:-} == yes ]] || return 0
+
+	local main_worktree
+
+	main_worktree="$(_resolve_main_worktree_dir)"
+
+	[[ -n ${main_worktree} && ${main_worktree} != "${WORKTREE_DIR}" ]] || return 0
+
+	local main_bundles
+
+	main_bundles="$(_find_app_server_parent_dir "${main_worktree}" 2>/dev/null)" || return 0
+
+	local source_file="${main_bundles}/portal-ext.properties"
+
+	[[ -f ${source_file} ]] || return 0
+
+	local target_file="${BUNDLES_DIR}/portal-ext.properties"
+
+	touch "${target_file}"
+
+	local extracted
+
+	extracted="$(awk '
+		NR == FNR {
+			if (/^[[:space:]]*feature\.flag\.[^=]+=/) {
+				key = $0
+
+				sub(/=.*/, "", key)
+				sub(/^[[:space:]]+/, "", key)
+
+				existing[key] = 1
+			}
+
+			next
+		}
+
+		/^[[:space:]]*#/ {
+			if (comment_buf == "") {
+				comment_buf = $0
+			}
+			else {
+				comment_buf = comment_buf "\n" $0
+			}
+
+			next
+		}
+
+		/^feature\.flag\.[^=]+=true$/ {
+			key = $0
+
+			sub(/=.*/, "", key)
+
+			if (!(key in existing)) {
+				if (comment_buf != "") {
+					print comment_buf
+				}
+
+				print $0
+			}
+
+			comment_buf = ""
+
+			next
+		}
+
+		{
+			comment_buf = ""
+		}
+	' "${target_file}" "${source_file}")"
+
+	[[ -n ${extracted} ]] || return 0
+
+	if [[ -s ${target_file} ]] && [[ -n $(tail --bytes=1 "${target_file}") ]]
+	then
+		echo "" >> "${target_file}"
+	fi
+
+	echo "${extracted}" >> "${target_file}"
+}
+
 function _bundle_exists {
 	local bundles_dir="${1}"
 
@@ -623,6 +704,8 @@ function main {
 	_set_test_auto_deploy_dir
 	_set_test_integration_port
 	_set_tomcat_ports
+
+	_bring_master_feature_flags
 
 	[[ -z ${LIFERAY_PROVISION_SKIP_TOMCAT:-} ]] && "$(_find_tomcat_dir "${BUNDLES_DIR}")/bin/catalina.sh" jpda start >&2
 

--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -198,18 +198,35 @@ function _set_database {
 	_set_property "${file}" jdbc.default.username "${existing_user}"
 	_set_property "${file}" jdbc.default.password "${existing_password}"
 
-	command -v mysql >/dev/null 2>&1 || return 0
+	local main_worktree
 
-	local mysql_args=()
+	main_worktree="$(_resolve_main_worktree_dir)"
 
-	if [[ -n ${existing_password} ]]
+	local container=
+	local root_password=
+
+	if [[ -n ${main_worktree} ]]
 	then
-		mysql_args+=(--password="${existing_password}")
+		container="$(_get_property "${main_worktree}/app.server.${USER}.properties" "worktree\.mysql\.container")"
+		root_password="$(_get_property "${main_worktree}/app.server.${USER}.properties" "worktree\.mysql\.root\.password")"
 	fi
 
-	mysql_args+=(--user "${existing_user}")
+	local mysql_command=()
 
-	mysql "${mysql_args[@]}" --execute "CREATE DATABASE IF NOT EXISTS ${db_name} CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;" >&2 || true
+	if [[ -n ${container} ]]
+	then
+		command -v docker >/dev/null 2>&1 || return 0
+
+		docker container inspect "${container}" >/dev/null 2>&1 || return 0
+
+		mysql_command=(docker exec --env "MYSQL_PWD=${root_password}" "${container}" mysql)
+	else
+		command -v mysql >/dev/null 2>&1 || return 0
+
+		mysql_command=(env "MYSQL_PWD=${root_password}" mysql)
+	fi
+
+	"${mysql_command[@]}" --user root --execute "CREATE DATABASE IF NOT EXISTS ${db_name} CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci; GRANT ALL ON ${db_name}.* TO '${existing_user}'@'%';" >&2 || true
 }
 
 function _set_debug_port {

--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -370,6 +370,13 @@ function _set_portal_http_address {
 	_set_property "${BUNDLES_DIR}/portal-ext.properties" portal.instance.inet.socket.address "localhost:${http_port}"
 }
 
+function _set_poshi_portal_url {
+	local file="${WORKTREE_DIR}/test.${USER}.properties"
+	local http_port=$((8080 + OFFSET))
+
+	_set_property "${file}" default.portal.url "http://localhost:${http_port}"
+}
+
 function _set_property {
 	local file="${1}"
 	local key="${2}"
@@ -510,6 +517,7 @@ function main {
 	_set_playwright_port
 	_set_portal_home
 	_set_portal_http_address
+	_set_poshi_portal_url
 	_set_test_auto_deploy_dir
 	_set_test_integration_port
 	_set_tomcat_ports

--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -387,6 +387,39 @@ function _set_property {
 	echo "${key}=${value}" >> "${file}"
 }
 
+function _set_test_auto_deploy_dir {
+	local source_file="${WORKTREE_DIR}/portal-impl/src/portal.properties"
+
+	[[ -f ${source_file} ]] || _die "${source_file} is missing."
+
+	local current_value
+
+	current_value="$(awk '
+		/^[[:space:]]*module\.framework\.auto\.deploy\.dirs=/ {
+			in_block = 1
+
+			sub(/^[[:space:]]*module\.framework\.auto\.deploy\.dirs=/, "")
+		}
+
+		in_block {
+			gsub(/[[:space:]]/, "")
+
+			if (sub(/\\$/, "")) {
+				printf "%s", $0
+			}
+			else {
+				print $0
+
+				exit
+			}
+		}
+	' "${source_file}")"
+
+	[[ -n ${current_value} ]] || _die "Unable to read module.framework.auto.deploy.dirs from ${source_file}."
+
+	_set_property "${BUNDLES_DIR}/portal-ext.properties" module.framework.auto.deploy.dirs "${current_value},\${module.framework.base.dir}/test"
+}
+
 function _set_test_integration_port {
 	local file="${WORKTREE_DIR}/.gradle/init.d/worktree-ports.gradle"
 
@@ -475,6 +508,7 @@ function main {
 	_set_playwright_port
 	_set_portal_home
 	_set_portal_http_address
+	_set_test_auto_deploy_dir
 	_set_test_integration_port
 	_set_tomcat_ports
 

--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -259,15 +259,41 @@ function _set_elasticsearch_ports {
 	fi
 
 	local file="${configs_dir}/com.liferay.portal.search.${es_version}.configuration.ElasticsearchConfiguration.config"
-	local sidecar=$((9201 + OFFSET))
-	local transport=$((9301 + OFFSET))
 
-	_atomic_write "${file}" <<EOF
+	local main_worktree
+
+	main_worktree="$(_resolve_main_worktree_dir)"
+
+	local endpoint=
+
+	if [[ -n ${main_worktree} ]]
+	then
+		endpoint="$(_get_property "${main_worktree}/app.server.${USER}.properties" "worktree\.elasticsearch\.endpoint")"
+	fi
+
+	local prefix
+
+	prefix="$(_derive_es_index_prefix "$(basename "${WORKTREE_DIR}")")"
+
+	if [[ -n ${endpoint} ]]
+	then
+		_atomic_write "${file}" <<EOF
+indexNamePrefix="${prefix}"
+networkHostAddresses=["${endpoint}"]
+productionModeEnabled=B"true"
+EOF
+	else
+		local sidecar=$((9201 + OFFSET))
+		local transport=$((9301 + OFFSET))
+
+		_atomic_write "${file}" <<EOF
+indexNamePrefix="${prefix}"
 sidecarHttpPort="${sidecar}"
 transportTcpPort="${transport}"
 networkBindHost="127.0.0.1"
 networkPublishHost="127.0.0.1"
 EOF
+	fi
 }
 
 function _set_glowroot_port {

--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -132,6 +132,8 @@ function _reuse_worktree {
 
 		_bundle_exists "${BUNDLES_DIR}" || _die "Bundle copy finished but no tomcat-* directory exists under ${BUNDLES_DIR}."
 	fi
+
+	(cd "${WORKTREE_DIR}" && ANT_OPTS="-Xmx2560m" ant setup-sdk >&2) || _die "ant setup-sdk failed under ${WORKTREE_DIR}."
 }
 
 function _sed_inplace {

--- a/.claude/rules/worktree-feature-flag-parity.md
+++ b/.claude/rules/worktree-feature-flag-parity.md
@@ -1,0 +1,43 @@
+---
+
+paths:
+  - ".claude/hooks/worktree-create.sh"
+
+---
+
+# Master Feature-Flag Parity On Worktree Create
+
+When a new worktree should inherit the curated `feature.flag.*=true` lines from the main worktree's `portal-ext.properties`, set `LIFERAY_BRING_MASTER_FLAGS=yes` before invoking the hook. The hook then walks the main worktree's `portal-ext.properties` for every `feature.flag.*=true` line and its immediately preceding contiguous comment lines, and appends each block idempotently to the new worktree's `portal-ext.properties`. Flags already present in the target are skipped, along with the comment lines associated only with those skipped flags.
+
+## Why Opt-In
+
+A fresh worktree off `upstream/master` should usually behave like master, but on short-lived experiment worktrees the user sometimes wants to verify behavior with stock flags. Defaulting off keeps the hook predictable; the env var makes the choice explicit.
+
+## Why Not Inside The Hook
+
+A hook invoked by `claude --worktree` runs without an interactive tty, so a `read --prompt` cannot work there. The hook honors only the explicit env var. Interactive UX lives in the consumer.
+
+## Interactive Prompt Shape For Consumers
+
+Any session or skill that wraps the hook should default the user into the parity flow with a tri-state prompt before invoking it. The recommended shape:
+
+```
+Master has <N> feature flags enabled. Bring them into the new worktree?
+  [Y]es     bring all (default, press Enter)
+  [s]elect  choose a subset
+  [n]o      skip
+```
+
+1. **Yes**: set `LIFERAY_BRING_MASTER_FLAGS=yes` and invoke the hook. The hook copies all flags.
+1. **Select**: show a numbered list of flag blocks, accept comma-separated indices (for example `1,3,5-7`), and write only the chosen blocks into the new worktree's `portal-ext.properties` directly. Do not pass the env var in this case.
+1. **No**: invoke the hook without the env var. No flags copied.
+
+Empty input means yes; the prompt fires once per worktree-create flow.
+
+## Idempotency Guarantee
+
+The hook checks each flag key against the target `portal-ext.properties` and skips any flag already present. Reruns with the same env var setting are safe and produce no duplicates.
+
+## Scope
+
+This rule covers the env-var-driven path in `worktree-create.sh`. Other portal-ext mutations (offset-derived ports, Liferay home, OSGi console) follow the conventions in the existing `_set_*` functions and do not need consumer guidance.

--- a/.claude/rules/worktree-long-running.md
+++ b/.claude/rules/worktree-long-running.md
@@ -1,0 +1,56 @@
+---
+
+paths:
+  - ".claude/hooks/worktree-create.sh"
+
+---
+
+# Consuming Long-Running Output From The Worktree-Create Hook
+
+The worktree-create hook redirects `ant all` (on the fresh provision path) to `${WORKTREE_DIR}/.worktree-ant-all.log`. The hook itself does not stream the output back through stdout, so any caller driving the hook from a long-lived session reads the log file to observe progress.
+
+## Why
+
+`ant all` produces tens of thousands of `[copy]`, `[exec]`, and `[sync-dir]` lines. Streaming that volume through a session's tool result floods context for no analytical value. The hook captures the output once to disk; consumers tail and grep the log instead.
+
+## Read Pattern
+
+Invoke the hook with `run_in_background` so the hook itself does not block the session. The harness notifies on completion.
+
+While the hook runs, attach a monitor to the log with a `grep` tuned for verdict and progress markers:
+
+```bash
+tail -f ${WORKTREE_DIR}/.worktree-ant-all.log | grep --line-buffered --extended-regexp '^BUILD (FAILED|SUCCESSFUL)|^\[(error|exec)\]|Exception'
+```
+
+The `--line-buffered` flag is mandatory; without it, pipe buffering delays events by minutes and defeats the purpose.
+
+## Heartbeat
+
+`ant all` is mostly silent between markers, so a heartbeat catches a stalled build before the completion notification arrives. Run alongside the verdict monitor:
+
+```bash
+while true
+do
+	if [ -s ${WORKTREE_DIR}/.worktree-ant-all.log ]
+	then
+		echo "heartbeat: log_size=$(stat --format=%s ${WORKTREE_DIR}/.worktree-ant-all.log)"
+	fi
+
+	sleep 60
+done
+```
+
+Three heartbeats with the same size indicate the log is no longer growing. Investigate before waiting another full build cycle.
+
+## Failure Diagnostic
+
+When `ant all` fails, the hook exits via `_die` and the message references the log path. The caller's diagnostic is:
+
+```bash
+tail --lines=50 ${WORKTREE_DIR}/.worktree-ant-all.log
+```
+
+## Scope
+
+This rule covers the `ant all` invocation in `worktree-create.sh`. The `ant setup-sdk` call on the reuse path currently still streams through `>&2`; its output is two orders of magnitude smaller. If it ever grows into a noise problem it gets the same treatment under a separate rule.


### PR DESCRIPTION
## Summary

Bundles ten atomic commits against `.claude/hooks/worktree-create.sh` (plus two new rule files), surfaced from gaps and improvement opportunities found while building a parallel user-level skill against the same hook. Each commit is independent; tail commits can be dropped in review if any are not worth merging.

## Commits

1. **Arquillian race fix** (`15634e6`): append `osgi/test` to `module.framework.auto.deploy.dirs` so the connector activates at Start Level on every boot.
1. **Setup SDK after reuse** (`df2b56f`): mirror LPD-90052 in the hook so the reuse path populates `tools/`.
1. **Poshi portal URL** (`308a46c`): write `default.portal.url` to `test.${USER}.properties` so offset > 0 worktrees do not target the main portal silently.
1. **Container DB routing** (`bf4c2d2`): optional `worktree.mysql.container` key routes the CREATE invocation through `docker exec`; CREATE uses `--user root` plus GRANT to the bundle user; optional `worktree.mysql.root.password` is passed through `MYSQL_PWD` env for hardened setups.
1. **ES shared mode + index prefix** (`51fc60c`): always write `indexNamePrefix=liferay-<slug>-` via a new `_derive_es_index_prefix`/`_derive_worktree_slug` pair in `_common.sh`; optional `worktree.elasticsearch.endpoint` switches to `productionModeEnabled=B"true"`.
1. **Marker survival** (`53b8572`): move `.worktree-port-offset` to the worktree root so `ant clean` no longer wipes it; legacy-path fallback during transition.
1. **Opt-in rebase** (`4bcc1ea`): `LIFERAY_WORKTREE_REFRESH_BASE=true` rebases the new worktree's branch onto `upstream/master`.
1. **Ant all log + consumer rule** (`cd12ab3`): redirect `ant all` to `.worktree-ant-all.log`; new rule documents Monitor + heartbeat shape for Claude consumers.
1. **ES detection cutoffs** (`66df956f`): layered fallback (existing config -> branch cutoff -> directory probe -> ES8 default).
1. **Feature flag parity + rule** (`d70e2cc`): `LIFERAY_BRING_MASTER_FLAGS=yes` brings master's `feature.flag.*=true` lines plus preceding comments; new rule documents the interactive prompt shape consumers should wrap around it.

## Open question for the reviewer

Commit 6 moves `.worktree-port-offset` out of the bundle directory so `ant clean` stops wiping it. The marker survives `ant clean` cleanly after the move, but it stays vulnerable to any `git clean -dfq` driven by `build.git.clean.command` (defined in `build.properties` at the repo root). Adding `-e '!.worktree-*'` to that exception list would close the gap end-to-end. The change lives outside `.claude/*` and would need to route through Brian on a separate PR. Worth pursuing as a follow-up, or do we leave the gap documented and move on?

## Verification

Local testing on Fedora 43, GNU sed 4.9, galatians-mysql + galatians-elasticsearch containers:

- Baseline: marker location, Poshi URL, ES sidecar prefix, no-flag-default-off all pass.
- Container routing: `worktree.mysql.container=galatians-mysql` creates the DB via `docker exec` and GRANTs the bundle user; trace confirms `MYSQL_PWD` env is in the docker exec command and `--password` never appears in args.
- ES shared mode: endpoint URL writes `productionModeEnabled` + `networkHostAddresses` correctly.
- Feature flag parity: env var brings master's `feature.flag.*=true` lines into a fresh target (17 flags exercised in the local test bundle); re-runs idempotent; removing a flag and re-running restores it; indented target keys are normalized in the dedup pass so no duplicates appear on rerun.
- Opt-in rebase: env var updates the new worktree's branch to `upstream/master`.
- ES detection cutoffs: static walk verifies six branch / directory combinations.
- Ant all log redirect: mock confirms the log file is created, `BUILD SUCCESSFUL` captured, and `_die` references the log path on failure.

## Note on LPD-91297

`_set_tomcat_ports` crashes on GNU sed 4.9 because `--regexp-extended` is placed after `--expression` (PR #643 has the fix in review). Local end-to-end testing required moving the flag temporarily; that change is NOT included in this PR.