### PR TITLE
LPD-91940 Improve worktree-create script robustness

### DIFF
--- a/.claude/hooks/_common.sh
+++ b/.claude/hooks/_common.sh
@@ -53,10 +53,10 @@ function _drop_database {
 	local user=root
 	local password=""
 
-	if [[ -n ${bundles_dir} && -f ${bundles_dir}/portal-ext.properties ]]
+	if [[ -n ${bundles_dir} ]]
 	then
-		user="$(_get_property "${bundles_dir}/portal-ext.properties" "jdbc\.default\.username" root)"
-		password="$(_get_property "${bundles_dir}/portal-ext.properties" "jdbc\.default\.password")"
+		user="$(_get_property_from_files "jdbc\.default\.username" root "${bundles_dir}/portal-ext.properties" "${bundles_dir}/portal-setup-wizard.properties")"
+		password="$(_get_property_from_files "jdbc\.default\.password" "" "${bundles_dir}/portal-ext.properties" "${bundles_dir}/portal-setup-wizard.properties")"
 	fi
 
 	local mysql_args=(--user "${user}")
@@ -127,4 +127,25 @@ function _get_property {
 	fi
 
 	echo "${value}"
+}
+
+function _get_property_from_files {
+	local key="${1}"
+	local default="${2}"
+
+	shift 2
+
+	local file
+
+	for file in "${@}"
+	do
+		if [[ -f ${file} ]] && grep --extended-regexp --quiet "^[[:space:]]*${key}=" "${file}"
+		then
+			grep --extended-regexp "^[[:space:]]*${key}=" "${file}" | tail --lines=1 | sed --regexp-extended "s/^[[:space:]]*${key}=[[:space:]]*//; s/[[:space:]]+\$//"
+
+			return
+		fi
+	done
+
+	echo "${default}"
 }

--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -185,11 +185,12 @@ function _set_database {
 	db_name="$(_derive_db_name "$(basename "${WORKTREE_DIR}")")"
 
 	local file="${BUNDLES_DIR}/portal-ext.properties"
+	local wizard_file="${BUNDLES_DIR}/portal-setup-wizard.properties"
 
 	local existing_user existing_password
 
-	existing_user="$(_get_property "${file}" "jdbc\.default\.username" root)"
-	existing_password="$(_get_property "${file}" "jdbc\.default\.password")"
+	existing_user="$(_get_property_from_files "jdbc\.default\.username" root "${file}" "${wizard_file}")"
+	existing_password="$(_get_property_from_files "jdbc\.default\.password" "" "${file}" "${wizard_file}")"
 
 	_set_property "${file}" jdbc.default.driverClassName com.mysql.cj.jdbc.Driver
 	_set_property "${file}" jdbc.default.url "jdbc:mysql://localhost/${db_name}?characterEncoding=UTF-8&dontTrackOpenResources=true&holdResultsOpenOverStatementClose=true&serverTimezone=GMT&useFastDateParsing=false&useUnicode=true"

--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -408,12 +408,12 @@ function _set_tomcat_ports {
 	local target_https=$((8443 + OFFSET))
 
 	_sed_inplace \
+		--regexp-extended \
 		--expression "/<Server/s/port=\"[0-9]+\"/port=\"${target_shutdown}\"/" \
 		--expression "/protocol=\"HTTP\\/1\\.1\"/s/port=\"[0-9]+\"/port=\"${target_http}\"/" \
 		--expression "/protocol=\"org\\.apache\\.coyote\\.http11\\.Http11NioProtocol\"/s/port=\"[0-9]+\"/port=\"${target_https}\"/" \
 		--expression "/<Connector protocol=\"AJP\\/1\\.3\"/,/\\/>/s/^([[:space:]]+)port=\"[0-9]+\"/\\1port=\"${target_ajp}\"/" \
 		--expression "s/redirectPort=\"[0-9]+\"/redirectPort=\"${target_https}\"/g" \
-		--regexp-extended \
 		"${file}"
 }
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,7 @@
 				"hooks": [
 					{
 						"command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/worktree-create.sh",
+						"timeout": 1800,
 						"type": "command"
 					}
 				]


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91940

## Summary

- Read JDBC credentials from `portal-setup-wizard.properties` when `portal-ext.properties` does not have them.
- Raise the `worktree-create` hook timeout to 30 minutes.
- Move sed's `--regexp-extended` flag before the `--expression` flags in `_set_tomcat_ports` so the AJP block parses in ERE and the `\1` backreference resolves.

## Test plan

- [ ] Create a fresh worktree and confirm the resulting `bundle/portal-ext.properties` carries the credentials from the main bundle, and that the Tomcat AJP port is rewritten without a `sed: invalid \1 reference` error.