### PR TITLE
LPD-92253 Run Poshi against a non-8080 worktree in test-fix

### DIFF
--- a/.claude/skills/test-fix/SKILL.md
+++ b/.claude/skills/test-fix/SKILL.md
@@ -145,7 +145,11 @@ Inspect the test source to discover which feature flags it depends on. Mirror th
 
 #### Run the Test
 
-Run the test, deploying first when the type requires it. For `Java Semantic Versioning`, the "test" is `<gradlew> baseline` from the failing module — strictly an API contract check, not a behavioral test. For test types that exercise the runtime (`Java Integration`, `Playwright`, `Poshi`), also read the server log after the run; it captures portal-side exceptions, deployment errors, and stack traces that never reach **errorTrace**, and frequently names the real failure. Then compare the local outcome with **errorTrace**:
+Run the test, deploying first when the type requires it. For `Java Semantic Versioning`, the "test" is `<gradlew> baseline` from the failing module — strictly an API contract check, not a behavioral test. For test types that exercise the runtime (`Java Integration`, `Playwright`, `Poshi`), also read the server log after the run; it captures portal-side exceptions, deployment errors, and stack traces that never reach **errorTrace**, and frequently names the real failure.
+
+For `Poshi`, run against the current checkout's Tomcat by following [`references/poshi-local-run.md`](references/poshi-local-run.md). It resolves the bundle's HTTP port and passes the URL overrides the runner needs — mandatory when the checkout is a `claude --worktree` whose Tomcat is not on `8080`, since without them Poshi resolves its `companyId` from whichever bundle owns `8080` and the setup aborts with `NoSuchUserException`.
+
+Then compare the local outcome with **errorTrace**:
 
 - **Test passes** → check whether a commit between `${FIRST_FAIL_SHA}` and `HEAD` already addresses the failure. When one does, exit with `Verdict: No fix needed`. Otherwise, reason about why the test failed in CI (the test may be flaky or fail for environmental reasons). Try to fix it and rerun to confirm. When no plausible cause surfaces, exit with `Verdict: No fix needed`. Skip **Identify Suspect Commits** and **Iterate Through Suspects** in either case.
 - **Same failure** → continue to **Identify Suspect Commits**.

--- a/.claude/skills/test-fix/references/poshi-local-run.md
+++ b/.claude/skills/test-fix/references/poshi-local-run.md
@@ -1,0 +1,91 @@
+# Poshi Local Run
+
+Use this procedure to run a `Poshi` test locally against the current checkout's
+Tomcat, including a `claude --worktree` checkout whose Tomcat is **not** on the
+default port `8080`. Running a Poshi test against a non-default port without the
+overrides below silently resolves data from whichever bundle owns `8080` and
+aborts the setup.
+
+## Resolve the Port
+
+`<port>` is the `port` attribute on the `<Connector>` element with
+`protocol="HTTP/1.1"` in `<tomcat>/conf/server.xml`, where `<tomcat>` is the
+`tomcat-*` directory under `<bundles>` (the highest version when several exist).
+Resolve it once and reuse it everywhere below.
+
+```bash
+grep -m1 'protocol="HTTP/1.1"' "<tomcat>/conf/server.xml" |
+	grep -o 'port="[0-9]*"'
+```
+
+When the port is `8080`, the overrides are harmless no-ops, so this procedure is
+safe to apply unconditionally.
+
+## The Problem
+
+The Poshi runner JAR (`com.liferay.poshi.runner-*.jar`) ships an internal
+`poshi.properties` with `portal.url=http://localhost:8080`. The macros read URLs
+from three different properties depending on the call site:
+
+- `JSONCompany.getPortalURL()` reads `instance.url`, falling back to
+  `portal.url`. Used for JSON-WS calls in most macros.
+
+- `JSONCompany.getDefaultPortalURL()` reads `default.portal.url`. Used inside
+  `getCompanyIdNoSelenium`, which resolves the `companyId` from a virtual host
+  lookup.
+
+- The `run-selenium-test` Ant target uses `test.url` for the URL Chrome
+  navigates to.
+
+Passing only `-Dtest.url=http://localhost:<port>` makes the browser hit the
+right port, but the JSON-WS curl calls in macros still go to `localhost:8080`
+because they read `portal.url` and `default.portal.url`. When another worktree
+is running on `8080`, Poshi resolves the `companyId` from that other bundle and
+then sends it as a path parameter to the target bundle. The mismatched
+`companyId` causes `getUserByEmailAddress` to return `NoSuchUserException`, and
+the setUp aborts with:
+
+```
+java.lang.Exception: TEST_SETUP_ERROR: No results for path: $['userId']
+```
+
+## The Solution
+
+Run from the checkout root, overriding all four URL properties plus the
+instance flag:
+
+```bash
+cd <repo-root>
+HOSTNAME=localhost ANT_OPTS="-Xmx2560m" ant \
+	-buildfile build-test.xml \
+	-Ddefault.portal.url=http://localhost:<port> \
+	-Dinstance.url=http://localhost:<port> \
+	-Dportal.url=http://localhost:<port> \
+	-Dtest.class="<name>" \
+	-Dtest.portal.instance=false \
+	-Dtest.url=http://localhost:<port> \
+	run-selenium-test
+```
+
+`<name>` is the Poshi test name exactly as returned by the Testray fetch (for
+example `LocalFile.StagingUsecase#AssertAssetPriorityNotBeResetAfterPublication`).
+
+`-D<property>=<value>` injects the value as a JVM system property, and
+`PropsUtil.get(...)` inside the macros reads system properties with priority
+over the packaged `poshi.properties`.
+
+The `test.portal.instance=false` flag tells Poshi not to create a virtual
+instance for this test. The virtual-instance setup performs its own JSON-WS
+calls that would also need the URL overrides; disabling it removes that path.
+
+## Verify
+
+When in doubt, grep the Poshi log for the curl invocations Poshi printed:
+
+```bash
+grep "Executing commands.*curl" <poshi-log>
+```
+
+Every URL should point at the same host and port. Any line that targets
+`localhost:8080` while the rest target the worktree port indicates a missing
+override.


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92253

## What is being fixed

When the test-fix skill runs under `claude --worktree`, the worktree's Tomcat listens on a non-default port. The Poshi runner JAR ships an internal `poshi.properties` with `portal.url=http://localhost:8080`, so its JSON-WS macros resolve the `companyId` from whichever bundle owns `8080` and the setUp aborts with `NoSuchUserException` ("No results for path: $['userId']").

## How it is being fixed

Adds `references/poshi-local-run.md` to the test-fix skill. It documents resolving the worktree's HTTP port and running with the four URL overrides (`default.portal.url`, `instance.url`, `portal.url`, `test.url`) plus `test.portal.instance=false`, and the Run the Test step now points at it for Poshi. Validated empirically: running `Login#LoginWithUIUsingWrongCredentials` against a worktree on port 8087 sent all six JSON-WS setUp calls to 8087 (none to 8080), resolved the `companyId` correctly, and the build passed.

## Why are there no tests?

Documentation-only change to a Claude Code skill under `.claude`; there is no product code path to cover.