### PR TITLE
LPD-92542 Assign unique port offsets to parallel worktrees

### DIFF
--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -332,6 +332,33 @@ function _set_port_offset {
 		return
 	fi
 
+	local lock_file
+	lock_file="$(git -C "${WORKTREE_DIR}" rev-parse --path-format=absolute --git-common-dir)/.worktree-port-offset.lock"
+
+	local lock_dir="${lock_file}.d"
+	local lock_fd
+	local use_flock=0
+
+	command -v flock >/dev/null 2>&1 && use_flock=1
+
+	if [[ ${use_flock} -eq 1 ]]
+	then
+		exec {lock_fd}>"${lock_file}"
+
+		flock "${lock_fd}"
+	else
+		local waited=0
+
+		until mkdir "${lock_dir}" 2>/dev/null
+		do
+			sleep 1
+
+			waited=$((waited + 1))
+
+			[[ ${waited} -lt 120 ]] || _die "Unable to acquire the port offset lock at ${lock_dir}."
+		done
+	fi
+
 	local claimed_offsets
 
 	claimed_offsets=" $(_collect_claimed_offsets | tr "\n" " ") "
@@ -347,11 +374,18 @@ function _set_port_offset {
 			OFFSET="${offset}"
 			echo "${OFFSET}" > "${offset_file}"
 
-			return
+			break
 		fi
 	done
 
-	_die "Unable to find a free port offset between 1 and 99."
+	if [[ ${use_flock} -eq 1 ]]
+	then
+		exec {lock_fd}>&-
+	else
+		rmdir "${lock_dir}" 2>/dev/null || true
+	fi
+
+	[[ -f ${offset_file} ]] || _die "Unable to find a free port offset between 1 and 99."
 }
 
 function _set_portal_home {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92542

## What is being fixed

Creating several agent worktrees at the same time made their Tomcats collide on ports. Each worktree gets a port offset (HTTP `8080+offset`, plus shutdown, AJP, debug, Elasticsearch, Gogo Shell, and related ports), but the selection in `_set_port_offset` had a time-of-check-to-time-of-use race. A concurrent run sees no sibling `.worktree-port-offset` file yet and no bound ports (Tomcat starts last), so every parallel run picks the same offset and lands on HTTP 8081. All but one of the portals then fail to bind with `java.net.BindException: Address already in use`, so the other parallel agents cannot boot and their tests cannot run. This was observed with three parallel test-fixer agents all assigned offset 1.

## How it is being fixed

The select-and-reserve step is wrapped in a shared lock keyed on the worktrees' common parent directory: `flock` on Linux, with a portable `mkdir` spinlock fallback for environments without `flock`. Each reservation is written to `.worktree-port-offset` and made visible to the next creator before it chooses, so concurrent runs receive distinct offsets. The `nc` port probe is now a secondary guard rather than the sole dedup signal, which never worked during parallel creation since no portal is listening yet.

## Why are there no tests?

The change is to a developer-tooling Git hook (`.claude/hooks/worktree-create.sh`) that lives outside the portal build and has no test harness in the repository. It was verified manually by extracting the real `_claim_port_offset` and `_set_port_offset` functions and running 8 concurrent claimers, each of which received a unique offset.
