### PR TITLE
LPD-92640 Add Jest testing conventions rule for Claude

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -121,3 +121,7 @@ Functional tests are a last resort, reserved for complete UI flows that cannot b
 ### Format Source
 
 Run `/format-source` (the `format-source` skill). See `.claude/skills/format-source/SKILL.md` for details.
+
+### JS Unit Testing
+
+When creating a new Jest test under `modules/**/*-web/test/`, read `.claude/rules/jest-testing.md` first; editing an existing test auto-loads it via the rule's `paths:`.

--- a/.claude/rules/jest-testing.md
+++ b/.claude/rules/jest-testing.md
@@ -1,0 +1,204 @@
+---
+
+paths:
+  - "modules/**/*-web/test/**/*.{js,ts,tsx}"
+
+---
+
+# Jest Testing
+
+Conventions for Jest and React Testing Library tests across `*-web` modules in the portal. Apply them whenever a test file is created or edited under any module.
+
+## Principles
+
+Tests assert behavior perceptible to the user, not internal implementation. Ask before each assertion: does this matter to the user?
+
+## File Naming
+
+Place tests in a sibling `test` directory at the module root, mirroring the subpath under `src/main/resources/META-INF/resources/js`. A source file at `src/main/resources/META-INF/resources/js/utils/convertRGBtoHex.ts` has its test at `test/utils/convertRGBtoHex.ts`.
+
+The shared Jest config in `modules/frontend-sdk/node-scripts/util/jest/getJestConfig.js` picks up every file under `test` via a `testMatch` pattern, except `test/stories` and `test/__lib__` which are excluded so they can hold fixtures, helpers, and Storybook artifacts.
+
+Do not colocate tests next to source files, and do not use `__tests__` directories.
+
+## Imports
+
+Import testing utilities from `@testing-library/react` (`render`, `screen`, `cleanup`, `fireEvent`, `waitFor`, `within`, `renderHook`, `act`) and `@testing-library/user-event`.
+
+Do not import from `@testing-library/react-hooks`; React 18 moved `renderHook` and `act` into `@testing-library/react`.
+
+Matchers like `toBeInTheDocument` and `toBeVisible` are auto-registered at runtime by the shared setup, but TypeScript cannot see them without the side-effect import, and the `yarn checkFormat` type check fails on every matcher call. Add the import on its own line after the external imports:
+
+```typescript
+import '@testing-library/jest-dom';
+```
+
+Stop at the side-effect import: named imports from that package or manual `expect.extend` calls duplicate what the shared setup already registers.
+
+## Anatomy
+
+A typical test renders the unit, drives it through `userEvent`, and asserts on the rendered output:
+
+```typescript
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import MappingInput from '../../../../src/main/resources/META-INF/resources/js/seo/display_page_templates/components/MappingInput';
+
+describe('MappingInput', () => {
+	it('adds the selected field to the input', async () => {
+		render(<MappingInput fieldTypes={['text']} fields={[{key: 'k1', label: 'L1', type: 'text'}]} label="Field" name="test" />);
+
+		await userEvent.click(screen.getByTitle('map'));
+		await userEvent.selectOptions(screen.getByLabelText('field'), 'k1');
+		await userEvent.click(screen.getByText('add-field'));
+
+		expect(screen.getByLabelText('Field')).toHaveValue('${k1:L1}');
+	});
+});
+```
+
+## Mocking
+
+Mock at the perimeter, not inside the application. Network calls and browser APIs the test should not hit (`fetch`, timers, `crypto`) are fair targets. Internal modules of the module under test are not; stubbing them isolates the test from real behavior and hides bugs the integration would catch.
+
+The shared setup under `modules/frontend-sdk/node-scripts/util/jest` installs the perimeter mocks tests need (`Liferay.*`, `fetch`, `jest-dom` matchers, timezone) so individual test files do not wire them. Use that surface as-is rather than reinstalling globals or replacing them with `jest.fn()`.
+
+## Shared Setup
+
+Every module that runs `yarn test` inherits two setup files from `modules/frontend-sdk/node-scripts/util/jest`: `setup.js` (via `setupFiles`) and `setupAfterEnv.js` (via `setupFilesAfterEnv`). Do not reinstall or reassign what they already provide.
+
+What comes pre-installed:
+
+1. **`global.Liferay`**: full mock from `mocks/Liferay.js` (events, `Language`, `ThemeDisplay`, `Util`, `Session`, `PortletKeys`, `FeatureFlags`, `Icons`, ...). Non-obvious defaults: `Language.get(key)` returns the key itself, `ThemeDisplay.getLanguageId()` returns `'en_US'`, `Util.openToast()` returns `true`.
+
+1. **`global.fetch`**: `jest-fetch-mock` enabled portal-wide. Drive responses with `fetch.mockResponseOnce(JSON.stringify(...))`. A `beforeEach` hook re-installs a spy that throws on unmocked calls, so tests must declare every expected network call.
+
+1. **`@testing-library/jest-dom` matchers**: registered globally.
+
+1. **Polyfills and environment**: `global.crypto`, `Headers`, `Image.prototype.decode`, `createRange()`, `regenerator-runtime`, `TextEncoder`/`TextDecoder`. CSS and SCSS imports route to an empty stub. Timezone is locked to `UTC`.
+
+### Overriding the Shared Mocks
+
+When a single case needs a different value than the shared default (for example, `Liferay.Util.openToast` returning a value other than `true`), override the shared `jest.fn` directly and restore the default in teardown. Do not wrap it in `jest.spyOn` and `mockRestore`: the shared mock is itself a `jest.fn`, so `mockRestore` strips its implementation and leaves it returning `undefined` for every later test in the worker.
+
+```javascript
+beforeEach(() => {
+	Liferay.Util.openToast.mockReturnValue(false);
+});
+
+afterEach(() => {
+	Liferay.Util.openToast.mockReturnValue(true);
+});
+```
+
+Antipatterns that shadow the shared mock and leak into every later test in the same worker:
+
+```typescript
+// Reassigning the Liferay surface
+(global as any).Liferay.Language.get = jest.fn((key) => `T(${key})`);
+global.Liferay = {Language: {get: jest.fn()}};
+
+// Conflicting with jest-fetch-mock
+global.fetch = jest.fn().mockResolvedValue({...});
+
+// Duplicating stubs the shared mock already provides
+jest.mock('frontend-js-web', () => ({sub: jest.fn(), fetch: jest.fn()}));
+```
+
+### Feature Flags
+
+The shared mock starts with `Liferay.FeatureFlags = {}`. Toggle a flag for a test by mutating that object directly: set the key in `beforeEach` (or `beforeAll` when the whole file needs it) and reset in the matching teardown.
+
+```typescript
+describe('RulesModal', () => {
+	beforeEach(() => {
+		Liferay.FeatureFlags['LPS-169837'] = true;
+	});
+
+	afterEach(() => {
+		Liferay.FeatureFlags['LPS-169837'] = false;
+	});
+
+	it('allows saving a rule', async () => {
+		renderComponent();
+
+		await userEvent.click(screen.getByText('save'));
+
+		expect(addRule).toHaveBeenCalled();
+	});
+});
+```
+
+### Before Writing a New Mock
+
+Check these locations in order before implementing your own:
+
+1. **`modules/frontend-sdk/node-scripts/util/jest/mocks`** for portal-wide stubs.
+
+1. **Your module's `test`** tree for project-local fixtures and helpers.
+
+## Lifecycle
+
+1. `@testing-library/react` auto-calls `cleanup` after every test as long as an `afterEach` exists in scope, so an explicit `afterEach(cleanup)` is not required. Tests that already include it are fine; do not add it in new code unless a specific case demands it.
+
+1. Reset call history with `jest.clearAllMocks()` in `beforeEach`. The shared Jest config does not set `clearMocks: true`, so call histories on `Liferay.*` and your own spies persist between tests unless cleared. `fetch` is the exception: the shared `setupAfterEnv.js` already calls `fetch.mockRestore()` in an `afterEach` hook, so you do not need to reset fetch yourself.
+
+1. Stub browser APIs and external modules with `jest.spyOn`, then call `jest.restoreAllMocks()` in `afterEach` so the spy does not leak into other suites. Note that `restoreAllMocks` only undoes `jest.spyOn` setups; for `jest.fn()` mocks, use `clearAllMocks` (history) or `resetAllMocks` (history + implementation) as needed.
+
+## Element Queries
+
+Follow the [Testing Library query priority](https://testing-library.com/docs/queries/about#priority):
+
+1. **Accessible to everyone**: `getByRole`, `getByLabelText`, `getByPlaceholderText`, `getByText`, `getByDisplayValue`.
+
+1. **Semantic queries**: `getByAltText`, `getByTitle`.
+
+1. **Test IDs**: `getByTestId`.
+
+Try to avoid `data-testid` and `container.querySelector` when a higher-priority query exists. `data-testid` ships to production unless stripped, creating an unofficial API; `querySelector` against a presentational class breaks with any visual refactor.
+
+## User Interaction
+
+Prefer `userEvent` over `fireEvent` and `await` every interaction; `userEvent` simulates the full event sequence (focus, keydown, input, keyup, change) that `fireEvent` skips.
+
+With fake timers, instantiate `userEvent` via `setup({advanceTimers: jest.advanceTimersByTime})`; otherwise its delays block on the frozen clock and the test hangs.
+
+```javascript
+jest.useFakeTimers();
+
+const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
+
+await user.upload(input, file);
+
+act(() => {
+	jest.runAllTimers();
+});
+
+jest.useRealTimers();
+```
+
+## Accessibility
+
+Tests for UI components should include accessibility assertions using `checkAccessibility` from `@liferay/layout-js-components-web/test/__lib__`. It wraps `axe-core` to assert zero violations against WCAG 2.1a, 2.1aa, and 2.2aa rulesets:
+
+```typescript
+// eslint-disable-next-line @liferay/portal/no-cross-module-deep-import
+import {checkAccessibility} from '@liferay/layout-js-components-web/test/__lib__/index';
+
+it('has no accessibility violations', async () => {
+	const {container} = render(<MyComponent {...DEFAULT_PROPS} />);
+
+	await checkAccessibility({bestPractices: true, context: container});
+});
+```
+
+The `bestPractices: true` flag enables additional checks beyond strict WCAG.
+
+Color contrast is not reliably testable in JSDOM and is disabled by default. Cover that case in Playwright tests if relevant.
+
+## Source
+
+- [Liferay frontend testing guidelines](https://github.com/liferay/liferay-frontend-projects/tree/master/guidelines/general/testing)
+- [Testing Library documentation](https://testing-library.com/docs)

--- a/.claude/rules/jest-testing.md
+++ b/.claude/rules/jest-testing.md
@@ -179,6 +179,22 @@ act(() => {
 jest.useRealTimers();
 ```
 
+## Debugging
+
+The `node-scripts test` wrapper appends `--silent` to every Jest run, so `console.log` and `screen.debug()` output never reaches the terminal. Re-enable it with the `--force-debug` flag:
+
+```bash
+yarn test path/to/Foo.test.tsx --force-debug
+```
+
+Every other Jest CLI flag passes through unchanged, so the usual iteration helpers compose with it:
+
+```bash
+yarn test path/to/Foo.test.tsx --force-debug --testNamePattern "<test title>"
+```
+
+Failure output (the DOM dump under a failed query, assertion diffs) is printed regardless of `--silent`; the flag is only needed for output the test itself logs.
+
 ## Accessibility
 
 Tests for UI components should include accessibility assertions using `checkAccessibility` from `@liferay/layout-js-components-web/test/__lib__`. It wraps `axe-core` to assert zero violations against WCAG 2.1a, 2.1aa, and 2.2aa rulesets:


### PR DESCRIPTION
## Summary

Adds `.claude/rules/jest-testing.md`, a Claude rule that captures the Jest and React Testing Library conventions used across `*-web` modules. The rule auto-injects when editing files under `modules/**/*-web/test/**`, so Claude-assisted test changes follow consistent patterns instead of reinventing them per file.

This is the Jest-only scope split off from a broader frontend-rules effort: the wider frontend conventions (state, services, forms, types) need Infra and a frontend council before landing in master. Jest stands alone because its conventions are tooling-validated (shared setup, ESLint) and align with the canonical Liferay frontend guidelines.

## Sections

- **Principles** — assert behavior perceptible to the user, not implementation.
- **File Naming** — sibling `test` tree mirroring source; no `__tests__`, no colocation.
- **Imports** — `@testing-library/{react,user-event}`; skip `react-hooks`; the `jest-dom` side-effect import is required for the matcher types (runtime registration is automatic, but the `checkFormat` type pass fails without it).
- **Anatomy** — canonical snippet from a real portal test.
- **Mocking** — mock at the perimeter, not inside the application.
- **Shared Setup** — pre-installed surface (`Liferay.*`, `fetch`, jest-dom matchers, polyfills), how to override (direct `jest.fn` override with teardown restore — `spyOn` + `mockRestore` breaks the shared mock — plus the feature flag pattern), antipatterns that shadow the shared mock.
- **Lifecycle** — `cleanup`, `clearAllMocks`, `restoreAllMocks` discipline.
- **Element Queries** — Testing Library priority (semantic > test IDs > `querySelector`).
- **User Interaction** — `userEvent` over `fireEvent`; fake timers with `advanceTimers`.
- **Debugging** — `node-scripts test` appends `--silent` to every Jest run; `--force-debug` re-enables `console.log`/`screen.debug()` output.
- **Accessibility** — `checkAccessibility` (axe-core) for UI components.
- **Source** — links to canonical guidelines.

Also adds a "Frontend Testing" pointer in `.claude/CLAUDE.md`.

## Test plan

- [x] Open a test file under `modules/**/*-web/test/**/*.{js,ts,tsx}` in Claude Code and confirm the rule auto-injects.
- [x] Stress-test the rule by writing new Jest suites with it against real components (`export-import-web` revamp pages): 26 tests passing plus a clean `yarn checkFormat`.
- [ ] Verify the Markdown renders correctly in the GitHub preview.