### PR TITLE
LPD-88576 Generalize poshi-migrate skill and untrack developer config

### DIFF
--- a/.claude/skills/poshi-migrate/.gitignore
+++ b/.claude/skills/poshi-migrate/.gitignore
@@ -1,0 +1,1 @@
+config.json

--- a/.claude/skills/poshi-migrate/SKILL.md
+++ b/.claude/skills/poshi-migrate/SKILL.md
@@ -1,0 +1,440 @@
+---
+
+argument-hint: "<component-name-or-testcase-path>"
+description: Migrate a Liferay Poshi .testcase file to its modern test layer (Playwright, Jest, JUnit unit, Java integration). Routes each test to the right layer, consolidates compatible tests at write-time, and follows existing Playwright patterns from a configurable reference folder. Use when the user asks to migrate, port, or convert a Poshi .testcase to Playwright, Jest, or JUnit.
+name: poshi-migrate
+
+---
+
+# Migrate Poshi Tests
+
+A playbook for migrating a Poshi `.testcase` file to the appropriate modern test layer. Each test is routed to **Playwright**, **Jest**, **JUnit unit**, or **Java integration** based on what it actually validates. Compatible Playwright tests sharing setup may be consolidated into a single test at write-time.
+
+This skill assumes the Poshi suite has already been triaged and shrunk if needed (`/poshi-shrink`). It does not run a Poshi-side consolidation pass — consolidation happens only when writing the modern test, and only when the merged form is clearly cleaner than separate tests.
+
+## Preconditions
+
+The working tree must be clean. Abort and ask the user to commit or stash first when dirty.
+
+## Inputs
+
+### Argument
+
+`${ARGUMENTS}` is either:
+
+1. A `@component-name` value. Scan the Poshi tests root for `.testcase` files whose `@component-name` matches, list them with their test counts, and ask the user to pick one.
+
+1. An absolute or repo-relative path to a single `.testcase` file. Use it directly.
+
+When `${ARGUMENTS}` is empty, resolve both the `@component-name` and the `.testcase` file interactively in two steps.
+
+#### Step 1: Resolve @component-name
+
+1. Read the root `test.properties` file at the repository root. Parse the `component.names=...` property, which is multi-line and uses `\` continuations with comma-separated values. Strip whitespace and trailing backslashes; the result is a flat list of component identifiers (`portal-acceptance`, `portal-analytics-cloud`, `portal-bpm`, …).
+
+1. Read `config.json` (when it exists) and check for `defaultComponentName`.
+
+	- When the value is set and still appears in the parsed list, ask the user with `AskUserQuestion` whether to keep `${defaultComponentName}` or pick another. When the user keeps the default, skip to Step 2.
+
+	- When the value is missing or no longer appears in the list, skip the question.
+
+1. Present the full parsed list to the user as plain text, one component per line, sorted alphabetically, prefixed by an index (`1. portal-acceptance`, `2. portal-analytics-cloud`, …). Append a final option such as `0. Type a custom component-name (not in the list)`. Ask the user to either pick an index or type a custom value. Validate the entered value against the regex `^[a-z0-9-]+$`; do not reject when the value is not in `test.properties` because product teams sometimes add component-names that are still pending registration.
+
+1. Persist the choice to `config.json` under `defaultComponentName` so the next invocation can suggest it as the default. Create `config.json` from `config.example.json` when it does not exist yet.
+
+#### Step 2: Resolve the .testcase File
+
+1. Search `${poshiTestsRoot}` recursively for `.testcase` files containing the line `@component-name = "${chosenComponent}"`. Capture, for each match, the repo-relative path and the test count (number of `test <Name> {` blocks).
+
+1. Sort the matches alphabetically by repo-relative path.
+
+1. Present the first 20 matches to the user as plain text with `<index>. <relative-path> (<N> tests)`. Append a final option such as `0. Type a repo-relative path (not in the list)`. Ask the user to either pick an index or type a repo-relative path manually (for files nested under a different root or not yet committed). Validate that the entered path resolves to an existing `.testcase` file before continuing.
+
+Use the chosen file path as the input for Phase 0 onwards.
+
+### Configuration
+
+`config.json` lives at `.claude/skills/poshi-migrate/config.json` but is intentionally not committed to the repository — each developer maintains their own. A `config.example.json` sits next to it with the suggested defaults; copy it and personalize when the defaults do not fit.
+
+Resolve configuration in this order:
+
+1. Read `config.json` when it exists.
+
+1. Otherwise, fall back to these defaults:
+
+	- **patternsReference**: `modules/test/playwright/tests/layout-content-page-editor-web` — the Playwright folder used as the style reference. Read at least one spec from here before writing the first migrated spec.
+
+	- **playwrightTestsRoot**: `modules/test/playwright/tests` — the root for Playwright specs.
+
+	- **poshiTestsRoot**: `portal-web/test/functional/com/liferay/portalweb/tests/enduser` — the root for Poshi `.testcase` files.
+
+	- **componentPlaywrightModules**: `{}` (empty). Phase 1 will ask the user which Playwright modules to scan when the mapping for the source `@component-name` is missing.
+
+	- **defaultComponentName**: unset. The argument resolver will prompt the user with the full list from `test.properties` and remember the choice from then on.
+
+The keys are:
+
+- **componentPlaywrightModules**: a mapping from `@component-name` to the list of Playwright modules under `playwrightTestsRoot` that own its existing specs. Phase 1 scans these modules to detect tests that already cover, or partially cover, the Poshi tests being migrated.
+
+- **defaultComponentName**: the last `@component-name` the user chose interactively. Suggested as the default on subsequent runs when `${ARGUMENTS}` is empty.
+
+- **patternsReference**: the Playwright folder used as the style reference.
+
+- **playwrightTestsRoot**: the root for Playwright specs.
+
+- **poshiTestsRoot**: the root for Poshi `.testcase` files.
+
+After resolving the values, show them to the user via `AskUserQuestion` and offer to keep them or override any value for this run. Persist overrides only when the user explicitly asks (write `config.json`, never modify `config.example.json`).
+
+## Workflow
+
+The skill runs in five phases: feasibility, inventory, plan, implement, validate. Each phase is gated on user approval.
+
+### Phase 0: Feasibility
+
+Before classifying anything, screen each `test` in the file for blockers that would make a migration to Playwright unviable today. Record the result for use in Phase 1.
+
+For each `test`, scan the body and every macro it transitively calls. Flag the test when it depends on any of the following:
+
+- **Synthetic events on a backend ingestion pipeline.** The test produces signals through real UI interactions (page visits, asset views, submissions) and waits for a flush job to surface them in the destination system. Without an API to seed those events directly, the migration cannot run in the Playwright budget.
+
+- **Multi-user sign-out / sign-in flows.** The test asserts behavior under a different identity using a chain of `logoutPG` / `loginPG` calls, often relying on seed users that are not isolated per run.
+
+- **Fresh tenants, workspaces, or instances created during the test.** The test provisions a new top-level container (workspace, virtual instance, isolated portal) as part of its setup, which the existing fixtures do not provision.
+
+- **Specialized seed sites or catalogs.** The test depends on an accelerator-provisioned site, a commerce catalog, or a template configuration that is not exposed through `apiHelpers`.
+
+- **Wizard UI shape as the assertion.** The test exists to verify the wizard UI itself (button labels, step order, banner copy). Replacing the wizard with an API setup defeats the test, so the migration must still drive the wizard — confirm that the wizard interactions are stable.
+
+Output of this phase, per test:
+
+| Classification | Meaning | Phase 1 follow-up |
+| --- | --- | --- |
+| **Migrate** | No blockers, or the only blockers are addressable by an API helper that already exists or that the migration will add. | Route to a layer in Phase 1. |
+| **Skip** | Blocked on a feature the modern test layer cannot reproduce today and that needs an API endpoint that does not exist yet. | Document the blocker and leave the test in the `.testcase`. Surface it in the plan so the team can prioritize the endpoint. |
+| **Drop** | Obsolete: already covered by an existing spec, or the product contract changed and the assertion no longer applies. | Remove the test from the `.testcase` in Phase 3 with a commit that names the covering spec or the contract change. |
+
+When a test is **Skip**, propose what the missing endpoint should look like (HTTP verb, path, payload, what UI flow it would replace) so the team can decide whether to build it. Do not improvise UI workarounds.
+
+### Phase 1: Inventory
+
+1. Read the `.testcase` file. Capture the `setUp`, `tearDown`, and every `test <Name>` block with its `@description`, `@priority`, and the macros or helper calls it invokes.
+
+1. Scan the Playwright modules listed in `componentPlaywrightModules` for the source `@component-name`. For every Poshi `test` not already marked **Skip** in Phase 0, classify the existing coverage as one of:
+
+	- **Already covered** — an existing spec exercises the same behavior end to end. Record the spec path. The test becomes **Drop** in the plan; it does not become a migration.
+
+	- **Partially covered** — an existing spec exercises part of the behavior or shares the same setup. Record the spec path so Phase 2 can plan an extension of that spec instead of a new file.
+
+	- **Not covered** — no existing spec touches the behavior. Continue to routing.
+
+	Compare each Poshi test against candidate specs across these signals (the more that align, the higher the confidence):
+
+	- **Description and comments** — does the Poshi `@description` or any header comment match the spec's `test(...)` title or section comments?
+
+	- **Functionality** — do both validate the same feature path (same panel, same flow, same final state)?
+
+	- **Selectors** — do the Poshi macro arguments (IDs, classes, and labels passed into `Click`, `AssertTextEquals`, and friends) overlap with the spec's `getByRole`, `getByLabel`, and `getByText` arguments? Resolve the macro to its `.macro` definition when the selector is not inline.
+
+	- **Structure** — same setup, same step order, same assertions in roughly the same place?
+
+	This is the most fragile part of the workflow; expect to iterate on the heuristic as false positives and false negatives surface. When the signals disagree, default to **Partially covered** and let the user resolve the call in Phase 2.
+
+	When `componentPlaywrightModules` does not list the source `@component-name`, ask the user which Playwright modules to scan before continuing. Do not skip this step.
+
+1. For every test whose `@description` references an LPS or LPD ticket, recover the original code change and use its diff as the primary signal for the layer decision. From the repo root:
+
+	```bash
+	git log \
+		--all \
+		--format="%H %s" \
+		--grep="^${TICKET}"
+	```
+
+	Run `git show <sha>` on each match to read the diff, and let the changed files drive the layer choice in the next step:
+
+	- Java `*Util`, formatter, parser, or pure-logic class with no service or runtime touch → JUnit unit.
+
+	- `.js`, `.jsx`, `.ts`, or `.tsx` module that does not import portal-runtime globals → Jest.
+
+	- `*LocalServiceImpl`, persistence layer, listener, or OSGi `@Component` → Java integration.
+
+	- JSP, taglib output, multi-module UI wiring, or anything that only manifests in the rendered page → Playwright.
+
+	Record the matching commit shas and the touched files in the per-test notes so Phase 2 can cite them in the plan. When `git log` returns no match (test predates the convention or the ticket never landed in this repo) record `ticket not in tree` and fall back to the heuristic table in the next step.
+
+1. For every `test` not classified as **Drop** or **Skip**, decide the routing in this order. Pick the first match. When the previous step recovered a ticket diff, treat its signal as the layer choice unless the diff and the test's actual assertions clearly disagree — in that case, record both signals and mark the test `unsure`.
+
+	| Layer | Pick When |
+	| --- | --- |
+	| **JUnit unit** | The test validates pure Java logic that does not need the portal runtime, services, or persistence. Common signal: assertions over plain values produced by a utility class, or behavior already reproducible at the package level. |
+	| **Jest** | The test validates frontend behavior that lives in a JavaScript or React module and can be reproduced without the portal — component rendering, state transitions, formatting, validation logic. |
+	| **Java integration** | The test exercises services, persistence, OSGi components, listeners, or portal-runtime behavior. Anything that needs a deployed bundle but does not need a real browser. |
+	| **Playwright** | Anything left: complete UI flows, multi-page navigation, browser-only behavior, JavaScript-driven interactions that a unit or integration test cannot cover. |
+
+	If you cannot place a test confidently, mark it `unsure` and flag it for the user in the plan. Do not invent a destination.
+
+1. For each test routed to Playwright, locate the destination spec folder under `playwrightTestsRoot`. The destination is the folder whose owning module renders the feature under test. When in doubt, search the Playwright tests root for an existing spec that imports or interacts with the same UI surface.
+
+### Phase 2: Plan
+
+Build the plan with `EnterPlanMode`. Format:
+
+```markdown
+## Source
+
+`<.testcase path>` — `@component-name = <value>`, `testray.main.component.name = <value>`, <N> tests.
+
+## Feasibility
+
+| Test | LPS/LPD | Decision | Blocker / Reason |
+| --- | --- | --- | --- |
+| `<TestName>` | `<TICKET>` | Migrate / Skip / Drop | <missing API endpoint / obsolete contract / etc> |
+
+## Existing Coverage
+
+| Test | LPS/LPD | Status | Covered By | Action |
+| --- | --- | --- | --- | --- |
+| `<TestName>` | `<TICKET>` | Already covered / Partially covered / Not covered | `<repo-relative spec path or —>` | Drop / Extend `<spec>` / Migrate |
+
+When every test is **Not covered**, write `None — no overlap with existing Playwright specs`.
+
+## Per-Test Routing
+
+Only includes tests classified as **Migrate** or **Partially covered** in earlier phases.
+
+| Test | LPS/LPD | Layer | Destination | Notes |
+| --- | --- | --- | --- | --- |
+| `<TestName>` | `<TICKET>` | Playwright / Jest / JUnit unit / Java integration | `<repo-relative path>` | <Consolidates with X / extends `<spec>` / new fixture needed / etc> |
+
+## Consolidations (Playwright)
+
+> **`<final-spec-name>.spec.ts`** (consolidates `<TestA>` + `<TestB>`):
+>
+> - Shared setup: <site, page, user>.
+> - Sequence: <step list>, ending with assertions for both LPS tickets.
+> - Tags: `@<TICKET-A>`, `@<TICKET-B>`.
+
+When no consolidation applies, write `None — one spec per test`.
+
+## New Helpers, Utils, or Fixtures
+
+List any new file under `helpers/`, `utils/`, or `fixtures/` you plan to add or extend, and the reason. When existing files cover the need, write `None — reuse existing`.
+
+## Proposed API Endpoints
+
+List every backend endpoint the migration would need but that does not exist yet. For each one, capture the HTTP verb, the path, the payload, and the UI flow it replaces. Mark dependent tests as **Skip** until the endpoint lands.
+
+## Skipped Tests
+
+| Test | LPS/LPD | Blocker | Proposed Unblocker |
+| --- | --- | --- | --- |
+| `<TestName>` | `<TICKET>` | <missing API / multi-tenant setup / etc> | <propose endpoint or fixture> |
+
+## Cleanup
+
+- Remove the **Drop** `test` blocks from `<.testcase path>` in their own commits, before any migration commits.
+- Remove the migrated `test` blocks from `<.testcase path>`.
+- Delete the `.testcase` file when it ends up empty.
+
+## Commits
+
+In order:
+
+1. One commit per **Drop** test (or per group sharing a covering spec), removing the test from the `.testcase` file. The commit message names the covering spec or the contract change that retired the test.
+
+1. New helper, util, or fixture commits, when any.
+
+1. One commit per migrated test or consolidated group.
+```
+
+The plan must be exhaustive: every `test` from Phase 1 appears in either the **Feasibility**, **Existing Coverage**, or **Per-Test Routing** table. Tests marked `unsure` go on their own row and the user must confirm a layer before continuing.
+
+### Phase 3: Implement
+
+After `ExitPlanMode` returns the user's approval, execute the plan in this order:
+
+1. **Drop cleanup commits** first. For every test classified as **Drop** in earlier phases, remove the `test` block from the source `.testcase` file (delete the file when it ends up empty), run `/format-source` on every changed file, and commit. The commit message must name the spec that already covers the test or the contract change that retired it. One commit per drop, or per group of drops sharing a single cause.
+
+1. **New helper, util, or fixture commits**, one per artifact. Verify the artifact does not already exist by scanning `<playwrightTestsRoot>/../{helpers,fixtures,utils}` before creating it.
+
+1. **Migration commits**, one per row in the routing table or per consolidation group. Each commit:
+
+	1. Writes the new test file at the planned destination.
+
+	1. Removes the migrated `test` blocks from the `.testcase` file. When the file ends up empty after the removals, delete the file in the same commit.
+
+	1. Runs `/format-source` on every changed file before staging.
+
+	1. Uses `/commit` to write the commit message.
+
+When implementing each layer, follow the rules below.
+
+#### Playwright
+
+Follow `.claude/rules/playwright.md` for the general conventions (layout, spec placement, anatomy, page classes, locators, setup, cleanup, flake-proofing utilities, feature flags). Do not duplicate or restate those rules here — read the file and apply it.
+
+Read at least one spec from the configured `patternsReference` folder before writing the first migrated spec to internalize the local idiom.
+
+The subsections below cover decisions that are specific to migrating from Poshi.
+
+##### API-First Setup Substitution
+
+When the Poshi `setUp` drives a UI flow (wizard, OAuth, sync between two services, signing in as another user, populating a configuration page), the migration must replace it with an API call. Climb the decision tree top-down, stopping at the first level that applies:
+
+1. **Existing Playwright helper.** Look under `<playwrightTestsRoot>/../{helpers,fixtures,utils}` for a helper that already replaces the flow (look for the verb in the macro name and synonyms: `connect`, `sync`, `assign`, `add`, `enable`). Use it. Compose with `mergeTests(...)` when a fixture exists.
+
+1. **No helper, but a backend endpoint exists.** When the product exposes a REST resource, a JSON web service, a headless endpoint, or a GraphQL mutation that performs the same effect as the UI flow, write a new helper in `<playwrightTestsRoot>/../helpers/<X>ApiHelper.ts` (or extend the existing one), register it on `ApiHelpers`, and consume it from the spec. Ship the helper in its own commit before the migration commit that uses it. Source the URL, payload shape, headers, and any envelope encoding from the backend code that owns the endpoint, not from a guess — wrong payloads typically surface as 500 errors with non-obvious messages.
+
+1. **No endpoint either.** Stop. Propose to the team adding the headless / JSON-web-services / REST endpoint that would unblock the test. Document the proposed contract (HTTP verb, path, payload, response shape) and what UI flow it replaces, then mark the test as **Skip** in the plan and return to the caller. Do not improvise UI workarounds — clicking through the wizard from the spec piles up flake and rots the moment the UI changes.
+
+Validate every new helper end-to-end against the running backend (`yarn test` on a one-test spike spec) before committing it. The connection envelope, payload shape, and headers must match what the backend expects.
+
+##### State Reset
+
+Modern specs cannot assume a clean starting state. Whatever the Poshi `tearDown` was clearing (preferences, configurations, per-tenant settings, sessions, lingering data sources from previous runs), the Playwright spec must reset before the assertion, not after — a previous run might have left residue.
+
+Two patterns work:
+
+1. **API reset in `test.beforeEach`.** Call the same REST / GraphQL mutation the UI uses to wipe the setting. Source the mutation name and shape from the frontend code that drives the UI.
+
+1. **Filter by dynamic state instead of hardcoded identifiers.** When the system creates entities with auto-incrementing names or environment-specific suffixes, do not assert on the name. Find the entity by its current state (status badge, "active" flag, freshly created flag) and read the name back from there.
+
+##### Cascading Fixtures
+
+When a migration needs site + user + connection between two services, compose existing isolated fixtures with `mergeTests(...)` instead of duplicating the setup. A common shape:
+
+```typescript
+import {mergeTests} from '@playwright/test';
+import {isolatedFooTest} from './isolatedFooTest';
+import {isolatedBarTest} from './isolatedBarTest';
+
+const test = mergeTests(isolatedFooTest, isolatedBarTest);
+
+const isolatedSyncedFooBarTest = test.extend<{
+	syncedFooBar: void;
+}>({
+	syncedFooBar: [
+		async ({apiHelpers, bar, foo}, use) => {
+			await connectFooAndBar({apiHelpers, bar, foo});
+
+			await use();
+
+			await disconnectFooAndBar({apiHelpers});
+		},
+		{auto: true},
+	],
+});
+```
+
+When the underlying connection is company-wide or otherwise non-isolated, force `workers: 1` and document the constraint in the fixture's doc comment.
+
+##### Setup Mappings
+
+Map Poshi setup actions to API helpers:
+
+- **Content page** (Poshi `JSONLayout.addLayout` or UI page creation) → `apiHelpers.headlessDelivery.createSitePage`. Pass a `pageDefinition` from the patternsReference utilities when fragments are needed.
+
+- **Mid-test login** (Poshi `User.logoutPG` plus `User.loginPG`) → `performLogout` followed by `performLogin` from `utils/performLogin`. Use a fresh user when the test mutates a per-user preference that would leak across runs.
+
+- **Site** (Poshi `JSONGroup.addGroup` or `Site.add`) → `apiHelpers.headlessAdminSite.postSite`. Prefer the `isolatedSiteTest` fixture, which provides a `site` with auto-cleanup.
+
+- **User** (Poshi `JSONUser.addUser`) → `apiHelpers.headlessAdminUser.postUserAccount`, then `assignUserToSite` with the role from `getRoleByName('Site Administrator')`. Register the user in `userData` so `performLogin` can sign in as that user.
+
+##### New Helpers, Utils, Fixtures
+
+When the migration requires a new artifact under `<playwrightTestsRoot>/../{helpers,fixtures,utils}`, scan the existing files for one that already covers the need before adding it. Extend an existing file rather than forking a new one. When a new artifact is genuinely needed, place it in the same folder structure and ship it in its own commit before the migration commit that uses it.
+
+##### Tagging
+
+Every migrated test carries `{tag: '@<TICKET>'}` where `<TICKET>` is the LPS or LPD identifier recovered in Phase 1. Consolidations carry every ticket they cover: `tag: ['@<TICKET-A>', '@<TICKET-B>']`.
+
+When the Poshi test has no ticket in its `@description` block and no LPS or LPD ticket surfaces from `git log --grep`, the migrated test goes without a tag. Do not invent a placeholder.
+
+#### Jest
+
+1. Place the new test under `<module-root>/test`, mirroring the path of the source file under test.
+
+1. Run with `cd <module-root> && yarn test <relative-path>`.
+
+1. Mock only what the JavaScript module under test cannot exercise directly. Avoid mocking the portal runtime — if you need it, the test belongs in Playwright or integration.
+
+1. Frontend conventions: `*.test.js`, `*.test.ts`, or `*.test.tsx` matching the module's existing pattern.
+
+#### JUnit Unit
+
+1. Place the new test under `<module-root>/src/test/java`, in the same package as the class under test.
+
+1. Run with `cd <module-root> && <gradlew> test --tests <TestClassName>`.
+
+1. The test must not require the portal runtime, services, or persistence.
+
+#### Java Integration
+
+1. Place the new test under `<module-root>/src/testIntegration/java`, in the same package as the class under test.
+
+1. Run with `cd <module-root> && <gradlew> testIntegration --tests <TestClassName>`.
+
+1. Follow the team conventions for Liferay integration tests: auto-cleanup via test rules and annotations rather than `@After` or manual deletion, `@FeatureFlags` per method when needed, trigger artifacts through real listeners.
+
+1. Reuse `*TestUtil` classes for fixtures.
+
+1. Use `TransformUtil.transformToArray` plus `ArrayUtil.contains` for "is `X` in list" assertions instead of manual loops.
+
+### Phase 4: Validate
+
+Tests against the runtime are not done until they pass against a live backend.
+
+For Playwright, run from the repo root:
+
+```bash
+cd modules/test/playwright && yarn test <relative-spec-path>
+```
+
+For JUnit and Jest, use the commands listed in the per-layer sections above.
+
+When a spec fails, follow the protocol below before claiming the migration done. Never `xfail`, comment out, or weaken an assertion to land the commit.
+
+#### When a Spec Fails
+
+Before retrying, gather the artifacts and decide:
+
+1. Open the screenshot at `test-results/<spec>/test-failed-N.png` and the `error-context.md` next to it. Compare them against what the spec expected.
+
+1. Identify the failure mode:
+
+	- **UI changed.** The assertion no longer matches the product contract. Drop the test (commit explaining the new behavior) or rewrite the assertion if the new behavior is still valuable.
+
+	- **Framework race.** The locator resolves correctly but the page is mid-render. Replace fixed waits with auto-retrying expectations (`expect(...).toHaveText`, `expect(...).toBeEnabled`) or use the existing wait helpers from `<playwrightTestsRoot>/../utils`.
+
+	- **Stale identifier.** The test assumes an environment-specific value (auto-incrementing name, seed user). Read the value from the current page state instead.
+
+	- **Real contract change.** The product behavior differs from what the Poshi test specified. Bring it to the feature owner before changing the assertion.
+
+	- **Missing API.** The setup landed but a downstream assertion fails because a state the Poshi test took for granted (synced data, populated metrics) is not seeded by the API path. Re-evaluate the test as **Skip** in the plan and surface the missing endpoint.
+
+#### Flake Check (Playwright Only)
+
+After the first green run, repeat each migrated Playwright spec ten times to surface flakiness from timing, viewport, or network races:
+
+```bash
+cd modules/test/playwright && yarn test --repeat-each=5 <relative-spec-path>
+```
+
+All ten runs must pass. When any run fails, fix the underlying race before declaring the migration done. Do not apply the flake check to Jest, JUnit unit, or Java integration tests — they are deterministic enough that the extra runs only burn time.
+
+## Output
+
+After the last commit, report:
+
+- The source `.testcase` (deleted or surviving with a tail of remaining tests).
+
+- The list of new files added, by layer, with their repo-relative paths and the LPS or LPD ticket they cover.
+
+- The list of new helpers, utils, or fixtures introduced, with one line each describing what they expose.
+
+- The list of tests classified as **Skip**, each with the blocker and the proposed endpoint or fixture that would unblock it.
+
+- Total commits made, in order.
+
+- Any test marked `unsure` that the user routed manually, plus the reasoning recorded in the plan.

--- a/.claude/skills/poshi-migrate/config.example.json
+++ b/.claude/skills/poshi-migrate/config.example.json
@@ -1,0 +1,7 @@
+{
+	"componentPlaywrightModules": {},
+	"defaultComponentName": "",
+	"patternsReference": "modules/test/playwright/tests/layout-content-page-editor-web",
+	"playwrightTestsRoot": "modules/test/playwright/tests",
+	"poshiTestsRoot": "portal-web/test/functional/com/liferay/portalweb/tests/enduser"
+}

--- a/modules/.releng/test/jenkins-results-parser/artifact.properties
+++ b/modules/.releng/test/jenkins-results-parser/artifact.properties
@@ -1,3 +1,3 @@
-artifact.git.id=15d19aa0249a7207c38152f27b9c547119aff08b
-artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.1827/com.liferay.jenkins.results.parser-1.0.1827-sources.jar
-artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.1827/com.liferay.jenkins.results.parser-1.0.1827.jar
+artifact.git.id=b8de1678f63c3ee5a8a2f1064de50675fac5e2b0
+artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.1828/com.liferay.jenkins.results.parser-1.0.1828-sources.jar
+artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.1828/com.liferay.jenkins.results.parser-1.0.1828.jar

--- a/modules/apps/site/site-api/src/main/java/com/liferay/site/manager/SitemapManager.java
+++ b/modules/apps/site/site-api/src/main/java/com/liferay/site/manager/SitemapManager.java
@@ -11,6 +11,8 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.xml.Element;
 
+import java.io.InputStream;
+
 import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
@@ -62,6 +64,11 @@ public interface SitemapManager {
 	public String getSitemap(
 			String assetType, String layoutUuid, long groupId,
 			boolean privateLayout, ThemeDisplay themeDisplay)
+		throws PortalException;
+
+	public InputStream getSitemapInputStream(
+			String assetTypeKey, String layoutUuid, long groupId,
+			boolean privateLayout, ThemeDisplay themeDisplay, int page)
 		throws PortalException;
 
 }

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
@@ -51,6 +51,12 @@ import com.liferay.site.configuration.manager.SitemapConfigurationManager;
 import com.liferay.site.constants.SitemapConstants;
 import com.liferay.site.manager.SitemapManager;
 import com.liferay.site.provider.SitemapURLProvider;
+import com.liferay.site.storage.helper.SitemapStorageHelper;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import java.nio.charset.StandardCharsets;
 
 import java.text.DateFormat;
 
@@ -283,6 +289,47 @@ public class SitemapManagerImpl implements SitemapManager {
 		return _getSitemap(layoutUuid, groupId, privateLayout, themeDisplay);
 	}
 
+	@Override
+	public InputStream getSitemapInputStream(
+			String assetTypeKey, String layoutUuid, long groupId,
+			boolean privateLayout, ThemeDisplay themeDisplay, int page)
+		throws PortalException {
+
+		long companyId = themeDisplay.getCompanyId();
+
+		if (_sitemapConfigurationManager.xmlSitemapIndexCompanyEnabled(
+				companyId) &&
+			StringUtil.equals(
+				_sitemapConfigurationManager.xmlSitemapIndexMode(companyId),
+				SitemapConstants.INDEX_MODE_ASSET_TYPE)) {
+
+			try {
+				if (assetTypeKey == null) {
+					return _sitemapStorageHelper.getSitemapInputStream(
+						companyId, groupId);
+				}
+
+				return _sitemapStorageHelper.getSitemapInputStream(
+					companyId, groupId, assetTypeKey, page);
+			}
+			catch (PortalException portalException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(portalException);
+				}
+			}
+		}
+
+		String xml = getSitemap(
+			getAssetTypeClassName(assetTypeKey), layoutUuid, groupId,
+			privateLayout, themeDisplay);
+
+		if (xml == null) {
+			return null;
+		}
+
+		return new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+	}
+
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		_serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
@@ -359,7 +406,20 @@ public class SitemapManagerImpl implements SitemapManager {
 
 		_removeEntriesAndSize(rootElement);
 
-		return document.asXML();
+		String xml = document.asXML();
+
+		try {
+			_sitemapStorageHelper.storeSitemapFile(
+				themeDisplay.getCompanyId(), groupId,
+				_assetTypeKeys.get(assetType), 1, xml);
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+		}
+
+		return xml;
 	}
 
 	private String _getFriendlyURL(String path, long groupId) {
@@ -429,10 +489,12 @@ public class SitemapManagerImpl implements SitemapManager {
 
 		_initEntriesAndSize(rootElement);
 
+		String xmlSitemapIndexMode =
+			_sitemapConfigurationManager.xmlSitemapIndexMode(
+				themeDisplay.getCompanyId());
+
 		if (StringUtil.equals(
-				_sitemapConfigurationManager.xmlSitemapIndexMode(
-					themeDisplay.getCompanyId()),
-				SitemapConstants.INDEX_MODE_ASSET_TYPE)) {
+				xmlSitemapIndexMode, SitemapConstants.INDEX_MODE_ASSET_TYPE)) {
 
 			String portalURL = themeDisplay.getPortalURL();
 
@@ -484,7 +546,23 @@ public class SitemapManagerImpl implements SitemapManager {
 
 		_removeEntriesAndSize(rootElement);
 
-		return document.asXML();
+		String xml = document.asXML();
+
+		if (StringUtil.equals(
+				xmlSitemapIndexMode, SitemapConstants.INDEX_MODE_ASSET_TYPE)) {
+
+			try {
+				_sitemapStorageHelper.storeSitemapFile(
+					themeDisplay.getCompanyId(), groupId, xml);
+			}
+			catch (Exception exception) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(exception);
+				}
+			}
+		}
+
+		return xml;
 	}
 
 	private List<LayoutSet> _getLayoutSets(
@@ -828,5 +906,8 @@ public class SitemapManagerImpl implements SitemapManager {
 
 	@Reference
 	private SitemapConfigurationManager _sitemapConfigurationManager;
+
+	@Reference
+	private SitemapStorageHelper _sitemapStorageHelper;
 
 }

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/struts/SitemapStrutsAction.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/struts/SitemapStrutsAction.java
@@ -5,7 +5,6 @@
 
 package com.liferay.site.internal.struts;
 
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.NoSuchLayoutSetException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -32,6 +31,8 @@ import com.liferay.site.manager.SitemapManager;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.InputStream;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -112,35 +113,26 @@ public class SitemapStrutsAction implements StrutsAction {
 			Group currentGroup = _groupLocalService.getGroup(
 				layoutSet.getGroupId());
 
-			if (currentGroup.isActive()) {
-				String assetTypeKey = ParamUtil.getString(
-					httpServletRequest, "assetTypeKey");
-
-				String assetTypeClassName =
-					_sitemapManager.getAssetTypeClassName(assetTypeKey);
-
-				String layoutUuid = ParamUtil.getString(
-					httpServletRequest, "layoutUuid");
-
-				String sitemap = _sitemapManager.getSitemap(
-					assetTypeClassName, layoutUuid, layoutSet.getGroupId(),
-					layoutSet.isPrivateLayout(), themeDisplay);
-
-				if (sitemap == null) {
-					httpServletResponse.sendError(
-						HttpServletResponse.SC_NOT_FOUND);
-
-					return null;
-				}
-
-				ServletResponseUtil.sendFile(
-					httpServletRequest, httpServletResponse, null,
-					sitemap.getBytes(StringPool.UTF8),
-					ContentTypes.TEXT_XML_UTF8);
-			}
-			else {
+			if (!currentGroup.isActive()) {
 				throw new NoSuchLayoutSetException();
 			}
+
+			InputStream inputStream = _sitemapManager.getSitemapInputStream(
+				ParamUtil.getString(httpServletRequest, "assetTypeKey"),
+				ParamUtil.getString(httpServletRequest, "layoutUuid"),
+				layoutSet.getGroupId(), layoutSet.isPrivateLayout(),
+				themeDisplay,
+				ParamUtil.getInteger(httpServletRequest, "page", 1));
+
+			if (inputStream == null) {
+				httpServletResponse.sendError(HttpServletResponse.SC_NOT_FOUND);
+
+				return null;
+			}
+
+			ServletResponseUtil.sendFile(
+				httpServletRequest, httpServletResponse, null, inputStream,
+				ContentTypes.TEXT_XML_UTF8);
 		}
 		catch (NoSuchLayoutSetException noSuchLayoutSetException) {
 			_portal.sendError(

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/internal/struts/test/SitemapStrutsActionTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/internal/struts/test/SitemapStrutsActionTest.java
@@ -6,25 +6,60 @@
 package com.liferay.site.internal.struts.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.display.page.constants.AssetDisplayPageConstants;
+import com.liferay.asset.display.page.service.AssetDisplayPageEntryLocalService;
+import com.liferay.journal.constants.JournalArticleConstants;
+import com.liferay.journal.constants.JournalFolderConstants;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.test.util.DisplayPageTemplateTestUtil;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.VirtualHostLocalService;
 import com.liferay.portal.kernel.struts.StrutsAction;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.TreeMapBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.xml.Document;
+import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.kernel.xml.SAXReader;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.constants.SitemapConstants;
+import com.liferay.site.manager.SitemapManager;
+import com.liferay.site.storage.helper.SitemapStorageHelper;
 
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,7 +77,48 @@ public class SitemapStrutsActionTest {
 	@ClassRule
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_companyConfigurationTemporarySwapper =
+			new CompanyConfigurationTemporarySwapper(
+				TestPropsValues.getCompanyId(),
+				_PID_SITEMAP_COMPANY_CONFIGURATION,
+				HashMapDictionaryBuilder.<String, Object>put(
+					"xmlSitemapIndexEnabled", true
+				).build());
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		_companyConfigurationTemporarySwapper.close();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_company = _companyLocalService.getCompany(
+			TestPropsValues.getCompanyId());
+
+		_group = GroupTestUtil.addGroup();
+
+		_layout = LayoutTestUtil.addTypePortletLayout(_group);
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_group.getGroupId());
+
+		_setUpThemeDisplay();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (_group != null) {
+			_sitemapStorageHelper.deleteSitemaps(
+				TestPropsValues.getCompanyId(), _group.getGroupId());
+		}
+	}
 
 	@Test
 	public void testExecute() throws Exception {
@@ -69,12 +145,9 @@ public class SitemapStrutsActionTest {
 
 		ThemeDisplay themeDisplay = new ThemeDisplay();
 
-		Company company = _companyLocalService.getCompany(
-			TestPropsValues.getCompanyId());
-
-		themeDisplay.setCompany(company);
+		themeDisplay.setCompany(_company);
 		themeDisplay.setPermissionChecker(
-			PermissionCheckerFactoryUtil.create(company.getGuestUser()));
+			PermissionCheckerFactoryUtil.create(_company.getGuestUser()));
 
 		mockHttpServletRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, themeDisplay);
@@ -101,13 +174,249 @@ public class SitemapStrutsActionTest {
 		Assert.assertEquals(200, mockHttpServletResponse.getStatus());
 	}
 
+	@Test
+	public void testExecuteReturnsSitemapIndexXMLFromDLStore()
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).put(
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
+						).build())) {
+
+			MockHttpServletResponse mockHttpServletResponse = _executeRequest(
+				null, null);
+
+			Assert.assertEquals(200, mockHttpServletResponse.getStatus());
+
+			Document document = _saxReader.read(
+				mockHttpServletResponse.getContentAsString());
+
+			Element rootElement = document.getRootElement();
+
+			Assert.assertEquals("sitemapindex", rootElement.getName());
+
+			List<Element> elements = rootElement.elements();
+
+			Assert.assertFalse(elements.isEmpty());
+
+			Assert.assertTrue(
+				_sitemapStorageHelper.hasSitemapFile(
+					TestPropsValues.getCompanyId(), _group.getGroupId()));
+		}
+	}
+
+	@Test
+	public void testExecuteReturnsWebContentSitemapXMLFromDLStore()
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).put(
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
+						).build())) {
+
+			_addJournalArticleAssetDisplayPageEntry(_addJournalArticle());
+
+			Map<String, String> assetTypeKeys =
+				_sitemapManager.getAssetTypeKeys();
+
+			MockHttpServletResponse mockHttpServletResponse = _executeRequest(
+				assetTypeKeys.get(JournalArticle.class.getName()), null);
+
+			Assert.assertEquals(200, mockHttpServletResponse.getStatus());
+
+			Document document = _saxReader.read(
+				mockHttpServletResponse.getContentAsString());
+
+			Element rootElement = document.getRootElement();
+
+			Assert.assertEquals("urlset", rootElement.getName());
+
+			List<Element> elements = rootElement.elements();
+
+			Assert.assertFalse(elements.isEmpty());
+
+			Assert.assertTrue(
+				_sitemapStorageHelper.hasSitemapFile(
+					TestPropsValues.getCompanyId(), _group.getGroupId(),
+					"web-content", 1));
+		}
+	}
+
+	@Test
+	public void testExecuteWithIndexDisabledDoesNotStore() throws Exception {
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", false
+						).build())) {
+
+			MockHttpServletResponse mockHttpServletResponse = _executeRequest(
+				null, null);
+
+			Assert.assertEquals(200, mockHttpServletResponse.getStatus());
+
+			Assert.assertFalse(
+				_sitemapStorageHelper.hasSitemapFile(
+					TestPropsValues.getCompanyId(), _group.getGroupId()));
+		}
+	}
+
+	@Test
+	public void testExecuteWithPageLayoutModeDoesNotStore() throws Exception {
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"xmlSitemapIndexEnabled", true
+						).put(
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_PAGE_LAYOUT
+						).build())) {
+
+			MockHttpServletResponse mockHttpServletResponse = _executeRequest(
+				null, _layout.getUuid());
+
+			Assert.assertEquals(200, mockHttpServletResponse.getStatus());
+
+			Assert.assertFalse(
+				_sitemapStorageHelper.hasSitemapFile(
+					TestPropsValues.getCompanyId(), _group.getGroupId()));
+		}
+	}
+
+	private JournalArticle _addJournalArticle() throws Exception {
+		Locale locale = LocaleUtil.getSiteDefault();
+
+		return JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			JournalArticleConstants.CLASS_NAME_ID_DEFAULT, StringPool.BLANK,
+			true, RandomTestUtil.randomLocaleStringMap(locale),
+			RandomTestUtil.randomLocaleStringMap(locale),
+			RandomTestUtil.randomLocaleStringMap(locale), null, locale, null,
+			false, false, _serviceContext);
+	}
+
+	private void _addJournalArticleAssetDisplayPageEntry(
+			JournalArticle journalArticle)
+		throws Exception {
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+				_group.getGroupId(),
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				journalArticle.getDDMStructureKey(), true,
+				WorkflowConstants.STATUS_APPROVED);
+
+		_assetDisplayPageEntryLocalService.addAssetDisplayPageEntry(
+			TestPropsValues.getUserId(), _group.getGroupId(),
+			_portal.getClassNameId(JournalArticle.class.getName()),
+			journalArticle.getResourcePrimKey(),
+			layoutPageTemplateEntry.getLayoutPageTemplateEntryId(),
+			AssetDisplayPageConstants.TYPE_SPECIFIC, _serviceContext);
+	}
+
+	private MockHttpServletResponse _executeRequest(
+			String assetTypeKey, String layoutUuid)
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(WebKeys.LAYOUT, _layout);
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _themeDisplay);
+		mockHttpServletRequest.setParameter(
+			"groupId", String.valueOf(_group.getGroupId()));
+
+		_themeDisplay.setRequest(mockHttpServletRequest);
+
+		if (assetTypeKey != null) {
+			mockHttpServletRequest.setParameter("assetTypeKey", assetTypeKey);
+		}
+
+		if (layoutUuid != null) {
+			mockHttpServletRequest.setParameter("layoutUuid", layoutUuid);
+		}
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		_sitemapStrutsAction.execute(
+			mockHttpServletRequest, mockHttpServletResponse);
+
+		return mockHttpServletResponse;
+	}
+
+	private void _setUpThemeDisplay() throws Exception {
+		_themeDisplay = ContentLayoutTestUtil.getThemeDisplay(
+			_company, _group, _layout);
+
+		_themeDisplay.setPortalDomain(_company.getVirtualHostname());
+		_themeDisplay.setPortalURL(_company.getPortalURL(_group.getGroupId()));
+		_themeDisplay.setServerName(_company.getVirtualHostname());
+		_themeDisplay.setServerPort(8080);
+	}
+
+	private static final String _PID_SITEMAP_COMPANY_CONFIGURATION =
+		"com.liferay.site.internal.configuration.SitemapCompanyConfiguration";
+
+	private static CompanyConfigurationTemporarySwapper
+		_companyConfigurationTemporarySwapper;
+
+	@Inject
+	private AssetDisplayPageEntryLocalService
+		_assetDisplayPageEntryLocalService;
+
+	private Company _company;
+
 	@Inject
 	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private Layout _layout;
+
+	@Inject
+	private Portal _portal;
+
+	@Inject
+	private SAXReader _saxReader;
+
+	private ServiceContext _serviceContext;
+
+	@Inject
+	private SitemapManager _sitemapManager;
+
+	@Inject
+	private SitemapStorageHelper _sitemapStorageHelper;
 
 	@Inject(
 		filter = "component.name=com.liferay.site.internal.struts.SitemapStrutsAction"
 	)
 	private StrutsAction _sitemapStrutsAction;
+
+	private ThemeDisplay _themeDisplay;
 
 	@Inject
 	private VirtualHostLocalService _virtualHostLocalService;

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
@@ -88,7 +88,9 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.redirect.model.RedirectEntry;
 import com.liferay.redirect.service.RedirectEntryLocalService;
+import com.liferay.site.constants.SitemapConstants;
 import com.liferay.site.manager.SitemapManager;
+import com.liferay.site.storage.helper.SitemapStorageHelper;
 import com.liferay.translation.info.item.provider.InfoItemLanguagesProvider;
 
 import java.io.Serializable;
@@ -106,6 +108,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -159,6 +162,14 @@ public class SitemapManagerTest {
 			_group.getGroupId());
 
 		_setUpThemeDisplay();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (_group != null) {
+			_sitemapStorageHelper.deleteSitemaps(
+				TestPropsValues.getCompanyId(), _group.getGroupId());
+		}
 	}
 
 	@Test
@@ -336,7 +347,8 @@ public class SitemapManagerTest {
 						).put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			ObjectEntry includedObjectEntry = _addObjectEntry(
@@ -387,7 +399,8 @@ public class SitemapManagerTest {
 						).put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			JournalArticle journalArticle = _addJournalArticle();
@@ -412,7 +425,8 @@ public class SitemapManagerTest {
 						HashMapDictionaryBuilder.<String, Object>put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			JournalArticle journalArticle = _addJournalArticle();
@@ -1164,7 +1178,8 @@ public class SitemapManagerTest {
 						HashMapDictionaryBuilder.<String, Object>put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			List<String> urls = new ArrayList<>();
@@ -1202,7 +1217,8 @@ public class SitemapManagerTest {
 						HashMapDictionaryBuilder.<String, Object>put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			JournalArticle journalArticle = _addJournalArticle();
@@ -1251,7 +1267,8 @@ public class SitemapManagerTest {
 						).put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			_assertSitemap(
@@ -1272,7 +1289,8 @@ public class SitemapManagerTest {
 						).put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			_assertSitemap(
@@ -1290,7 +1308,8 @@ public class SitemapManagerTest {
 						).put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			_assertSitemap(
@@ -1312,7 +1331,8 @@ public class SitemapManagerTest {
 						).put(
 							"xmlSitemapIndexEnabled", true
 						).put(
-							"xmlSitemapIndexMode", _INDEX_MODE_ASSET_TYPE
+							"xmlSitemapIndexMode",
+							SitemapConstants.INDEX_MODE_ASSET_TYPE
 						).build())) {
 
 			_assertSitemap(false, _group.getGroupId(), StringPool.BLANK);
@@ -1849,8 +1869,6 @@ public class SitemapManagerTest {
 	private static final String _CLASS_NAME_OBJECT_ENTRY =
 		ObjectEntry.class.getName();
 
-	private static final String _INDEX_MODE_ASSET_TYPE = "asset-type";
-
 	private static final String _PID_SITEMAP_COMPANY_CONFIGURATION =
 		"com.liferay.site.internal.configuration.SitemapCompanyConfiguration";
 
@@ -1926,6 +1944,9 @@ public class SitemapManagerTest {
 
 	@Inject
 	private SitemapManager _sitemapManager;
+
+	@Inject
+	private SitemapStorageHelper _sitemapStorageHelper;
 
 	private ThemeDisplay _themeDisplay;
 

--- a/modules/sdk/ant-build-logger/build.gradle
+++ b/modules/sdk/ant-build-logger/build.gradle
@@ -8,7 +8,7 @@ clean {
 }
 
 dependencies {
-	compileOnly group: "com.liferay", name: "com.liferay.jenkins.results.parser", version: "1.0.1827"
+	compileOnly group: "com.liferay", name: "com.liferay.jenkins.results.parser", version: "1.0.1828"
 	compileOnly group: "org.apache.ant", name: "ant", version: "1.10.14"
 }
 

--- a/modules/sdk/ant-secure-property/build.gradle
+++ b/modules/sdk/ant-secure-property/build.gradle
@@ -8,7 +8,7 @@ clean {
 }
 
 dependencies {
-	compileOnly group: "com.liferay", name: "com.liferay.jenkins.results.parser", version: "1.0.1827"
+	compileOnly group: "com.liferay", name: "com.liferay.jenkins.results.parser", version: "1.0.1828"
 	compileOnly group: "org.apache.ant", name: "ant", transitive: false, version: "1.10.14"
 }
 

--- a/modules/test/jenkins-results-parser/bnd.bnd
+++ b/modules/test/jenkins-results-parser/bnd.bnd
@@ -1,3 +1,3 @@
 Bundle-Name: Liferay Jenkins Results Parser
 Bundle-SymbolicName: com.liferay.jenkins.results.parser
-Bundle-Version: 1.0.1828
+Bundle-Version: 1.0.1829

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -10,12 +10,8 @@ import com.google.common.collect.Lists;
 import java.io.File;
 import java.io.IOException;
 
-import java.time.Duration;
-import java.time.Instant;
-
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -900,51 +896,6 @@ public abstract class BaseWorkspaceGitRepository
 		String senderBranchSHA = getSenderBranchSHA();
 
 		if (!gitWorkingDirectory.localSHAExists(senderBranchSHA)) {
-			if (JenkinsResultsParserUtil.isCloudCINode()) {
-				try {
-					GitHubRemoteGitCommit gitHubRemoteGitCommit =
-						GitCommitFactory.newGitHubRemoteGitCommit(
-							getSenderBranchUsername(),
-							gitWorkingDirectory.getGitRepositoryName(),
-							senderBranchSHA);
-
-					Date commitDate = gitHubRemoteGitCommit.getCommitDate();
-
-					Instant commitInstant = commitDate.toInstant();
-
-					Instant oneMonthAgo = Instant.now(
-					).minus(
-						Duration.ofDays(30)
-					);
-
-					if (commitInstant.isBefore(oneMonthAgo) &&
-						_isPullRequest()) {
-
-						PullRequest pullRequest =
-							PullRequestFactory.newPullRequest(getGitHubURL());
-
-						if (pullRequest != null) {
-							String message =
-								"User's commit " + senderBranchSHA +
-									" is more than 1 month old. Rebase and " +
-										"retest your changes.";
-
-							pullRequest.addComment(message);
-
-							throw new RuntimeException(
-								"Sender's commit is more than 1 month old");
-						}
-					}
-				}
-				catch (Exception exception) {
-					exception.printStackTrace();
-
-					throw new RuntimeException(
-						"Sender's commit is more than 1 month old or there " +
-							"was an error retrieving commit information");
-				}
-			}
-
 			gitWorkingDirectory.fetch(_getSenderRemoteGitRef());
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -1438,10 +1438,10 @@ public abstract class BaseWorkspaceGitRepository
 
 		GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
 
-		gitWorkingDirectory.fetch(remoteGitRef);
+		LocalGitBranch localGitBranch = gitWorkingDirectory.fetch(remoteGitRef);
 
-		if (!gitWorkingDirectory.localSHAExists(sha) ||
-			!gitWorkingDirectory.refContainsSHA(remoteGitRef.getSHA(), sha)) {
+		if ((localGitBranch == null) ||
+			!gitWorkingDirectory.refContainsSHA(localGitBranch, sha)) {
 
 			throw new RuntimeException(
 				JenkinsResultsParserUtil.combine(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -800,9 +800,7 @@ public class CIForwardProcessor {
 
 			String message = gitWorkingDirectoryRuntimeException.getMessage();
 
-			if ((message != null) && message.contains("Unable to rebase ") &&
-				message.contains("CONFLICT (")) {
-
+			if ((message != null) && message.contains("Unable to rebase ")) {
 				System.out.println(
 					JenkinsResultsParserUtil.combine(
 						"Detected merge conflict between ",
@@ -815,8 +813,8 @@ public class CIForwardProcessor {
 			}
 
 			System.out.println(
-				"WARNING: Unable to detect merge conflict marker but rebase " +
-					"failed\n" + String.valueOf(message));
+				"WARNING: Unable to determine merge conflict status\n" +
+					String.valueOf(message));
 
 			return false;
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -776,47 +776,41 @@ public class CIForwardProcessor {
 		}
 
 		String expectedMergeBaseSHA = mergeBaseCommit.getSHA();
-		String receiverSHA = receiverRemoteGitBranch.getSHA();
-		String senderSHA = _pullRequest.getSenderSHA();
 
-		Date mergeBaseCommitDate = mergeBaseCommit.getCommitDate();
-
-		gitWorkingDirectory.fetch(receiverRemoteGitBranch, mergeBaseCommitDate);
-		gitWorkingDirectory.fetch(senderRemoteGitBranch, mergeBaseCommitDate);
-
-		if (!_localMergeBaseMatches(
-				gitWorkingDirectory, senderSHA, receiverSHA,
-				expectedMergeBaseSHA)) {
-
-			Date deepenedSinceDate = new Date(
-				mergeBaseCommitDate.getTime() -
-					_BRANCH_DEEPENING_STEP_SIZE_MILLIS);
-
-			gitWorkingDirectory.fetch(
-				receiverRemoteGitBranch, deepenedSinceDate);
-			gitWorkingDirectory.fetch(senderRemoteGitBranch, deepenedSinceDate);
-
-			if (!_localMergeBaseMatches(
-					gitWorkingDirectory, senderSHA, receiverSHA,
-					expectedMergeBaseSHA)) {
-
-				System.out.println(
-					"WARNING: Unable to identify merge base SHA");
-
-				return false;
-			}
-		}
+		gitWorkingDirectory.fetch(receiverRemoteGitBranch);
+		gitWorkingDirectory.fetch(senderRemoteGitBranch);
 
 		LocalGitBranch receiverLocalGitBranch =
 			gitWorkingDirectory.createLocalGitBranch(
 				JenkinsResultsParserUtil.combine(
 					_recipientUsername, "-", upstreamBranchName, "-precheck"),
-				true, receiverSHA);
+				true, receiverRemoteGitBranch.getSHA(),
+				receiverRemoteGitBranch);
 
 		LocalGitBranch senderLocalGitBranch =
 			gitWorkingDirectory.createLocalGitBranch(
 				_pullRequest.getLocalSenderBranchName() + "-precheck", true,
-				senderSHA);
+				_pullRequest.getSenderSHA(), senderRemoteGitBranch);
+
+		String localMergeBaseSHA = null;
+
+		try {
+			localMergeBaseSHA = gitWorkingDirectory.getMergeBaseCommitSHA(
+				receiverLocalGitBranch, senderLocalGitBranch);
+		}
+		catch (GitWorkingDirectory.GitWorkingDirectoryRuntimeException
+					gitWorkingDirectoryRuntimeException) {
+
+			gitWorkingDirectoryRuntimeException.printStackTrace();
+		}
+
+		if ((localMergeBaseSHA == null) ||
+			!expectedMergeBaseSHA.equals(localMergeBaseSHA.trim())) {
+
+			System.out.println("WARNING: Unable to identify merge base SHA");
+
+			return false;
+		}
 
 		try {
 			gitWorkingDirectory.rebase(
@@ -864,31 +858,6 @@ public class CIForwardProcessor {
 
 		return failedRequiredPassingTestSuiteNames.isEmpty();
 	}
-
-	private boolean _localMergeBaseMatches(
-		GitWorkingDirectory gitWorkingDirectory, String senderSHA,
-		String receiverSHA, String expectedMergeBaseSHA) {
-
-		try {
-			String localMergeBaseSHA =
-				gitWorkingDirectory.getMergeBaseCommitSHA(
-					senderSHA, receiverSHA);
-
-			if (localMergeBaseSHA != null) {
-				localMergeBaseSHA = localMergeBaseSHA.trim();
-			}
-
-			return expectedMergeBaseSHA.equals(localMergeBaseSHA);
-		}
-		catch (GitWorkingDirectory.GitWorkingDirectoryRuntimeException
-					gitWorkingDirectoryRuntimeException) {
-
-			return false;
-		}
-	}
-
-	private static final long _BRANCH_DEEPENING_STEP_SIZE_MILLIS =
-		1000L * 60L * 60L * 24L;
 
 	private static final long _RETRY_PERIOD = 1000L * 60L;
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CIForwardProcessor.java
@@ -768,14 +768,11 @@ public class CIForwardProcessor {
 			gitWorkingDirectory.getRemoteGitBranch(
 				upstreamBranchName, receiverRemoteURL, true);
 
-		GitCommit mergeBaseCommit = receiverRemoteGitBranch.getMergeBaseCommit(
-			senderRemoteGitBranch);
+		if (receiverRemoteGitBranch.getMergeBaseCommit(senderRemoteGitBranch) ==
+				null) {
 
-		if (mergeBaseCommit == null) {
 			return false;
 		}
-
-		String expectedMergeBaseSHA = mergeBaseCommit.getSHA();
 
 		gitWorkingDirectory.fetch(receiverRemoteGitBranch);
 		gitWorkingDirectory.fetch(senderRemoteGitBranch);
@@ -791,26 +788,6 @@ public class CIForwardProcessor {
 			gitWorkingDirectory.createLocalGitBranch(
 				_pullRequest.getLocalSenderBranchName() + "-precheck", true,
 				_pullRequest.getSenderSHA(), senderRemoteGitBranch);
-
-		String localMergeBaseSHA = null;
-
-		try {
-			localMergeBaseSHA = gitWorkingDirectory.getMergeBaseCommitSHA(
-				receiverLocalGitBranch, senderLocalGitBranch);
-		}
-		catch (GitWorkingDirectory.GitWorkingDirectoryRuntimeException
-					gitWorkingDirectoryRuntimeException) {
-
-			gitWorkingDirectoryRuntimeException.printStackTrace();
-		}
-
-		if ((localMergeBaseSHA == null) ||
-			!expectedMergeBaseSHA.equals(localMergeBaseSHA.trim())) {
-
-			System.out.println("WARNING: Unable to identify merge base SHA");
-
-			return false;
-		}
 
 		try {
 			gitWorkingDirectory.rebase(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitBranchFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitBranchFactory.java
@@ -16,6 +16,14 @@ public class GitBranchFactory {
 		return new LocalGitBranch(localGitRepository, name, sha);
 	}
 
+	public static LocalGitBranch newLocalGitBranch(
+		LocalGitRepository localGitRepository, String name, String sha,
+		RemoteGitBranch sourceRemoteGitBranch) {
+
+		return new LocalGitBranch(
+			localGitRepository, name, sha, sourceRemoteGitBranch);
+	}
+
 	public static RemoteGitRef newRemoteGitRef(
 		RemoteGitRepository remoteGitRepository, String name, String sha,
 		String type) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -2733,6 +2733,29 @@ public class GitWorkingDirectory {
 		}
 	}
 
+	public boolean refContainsSHA(LocalGitBranch localGitBranch, String sha) {
+		for (int deepenAttempt = 0;; deepenAttempt++) {
+			if (refContainsSHA(localGitBranch.getName(), sha)) {
+				return true;
+			}
+
+			boolean deepened = false;
+
+			if (deepenAttempt < _DEEPEN_MAX_ATTEMPTS) {
+				Date shallowSinceDate = new Date(
+					JenkinsResultsParserUtil.getCurrentTimeMillis() -
+						(_DEEPEN_STEP_SIZE_MILLIS << deepenAttempt));
+
+				deepened = deepenLocalGitBranch(
+					localGitBranch, shallowSinceDate);
+			}
+
+			if (!deepened) {
+				return false;
+			}
+		}
+	}
+
 	public boolean refContainsSHA(String ref, String sha) {
 		GitUtil.ExecutionResult executionResult = executeBashCommands(
 			GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY, 1000 * 60 * 2,

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -499,6 +499,27 @@ public class GitWorkingDirectory {
 		return retryable.executeWithRetries();
 	}
 
+	public boolean deepenLocalGitBranch(
+		LocalGitBranch localGitBranch, Date shallowSinceDate) {
+
+		RemoteGitBranch sourceRemoteGitBranch =
+			localGitBranch.getSourceRemoteGitBranch();
+
+		if (sourceRemoteGitBranch == null) {
+			return false;
+		}
+
+		System.out.println(
+			JenkinsResultsParserUtil.combine(
+				"Deepening ", localGitBranch.getName(), " to ",
+				JenkinsResultsParserUtil.toDateString(
+					shallowSinceDate, "yyyy-MM-dd'T'HH:mm:ss'Z'", "UTC")));
+
+		fetch(sourceRemoteGitBranch, shallowSinceDate);
+
+		return true;
+	}
+
 	public void deleteLocalGitBranch(LocalGitBranch localGitBranch) {
 		if (localGitBranch == null) {
 			return;
@@ -1635,45 +1656,28 @@ public class GitWorkingDirectory {
 				return executionResult.getStandardOut();
 			}
 
-			boolean canDeepen = false;
+			boolean deepened = false;
 
-			for (LocalGitBranch localGitBranch : localGitBranches) {
-				if (localGitBranch.getSourceRemoteGitBranch() != null) {
-					canDeepen = true;
+			if (deepenAttempt < _DEEPEN_MAX_ATTEMPTS) {
+				Date shallowSinceDate = new Date(
+					JenkinsResultsParserUtil.getCurrentTimeMillis() -
+						(_DEEPEN_STEP_SIZE_MILLIS << deepenAttempt));
 
-					break;
+				for (LocalGitBranch localGitBranch : localGitBranches) {
+					if (deepenLocalGitBranch(
+							localGitBranch, shallowSinceDate)) {
+
+						deepened = true;
+					}
 				}
 			}
 
-			if (!canDeepen ||
-				(deepenAttempt >= _MERGE_BASE_DEEPEN_MAX_ATTEMPTS)) {
-
+			if (!deepened) {
 				throw new GitWorkingDirectoryRuntimeException(
 					this,
 					JenkinsResultsParserUtil.combine(
 						"Unable to get merge base commit SHA\n",
 						executionResult.getStandardError()));
-			}
-
-			Date shallowSinceDate = new Date(
-				JenkinsResultsParserUtil.getCurrentTimeMillis() -
-					(_MERGE_BASE_DEEPEN_STEP_SIZE_MILLIS << deepenAttempt));
-
-			System.out.println(
-				JenkinsResultsParserUtil.combine(
-					"WARNING: No merge base found within the local shallow ",
-					"horizon. Deepening to ",
-					JenkinsResultsParserUtil.toDateString(
-						shallowSinceDate, "yyyy-MM-dd'T'HH:mm:ss'Z'", "UTC"),
-					" and retrying."));
-
-			for (LocalGitBranch localGitBranch : localGitBranches) {
-				RemoteGitBranch sourceRemoteGitBranch =
-					localGitBranch.getSourceRemoteGitBranch();
-
-				if (sourceRemoteGitBranch != null) {
-					fetch(sourceRemoteGitBranch, shallowSinceDate);
-				}
 			}
 		}
 	}
@@ -1948,9 +1952,6 @@ public class GitWorkingDirectory {
 			LocalGitBranch rebasedLocalGitBranch = createLocalGitBranch(
 				rebasedLocalGitBranchName, true, senderSHA,
 				senderRemoteGitBranch);
-
-			getMergeBaseCommitSHA(
-				upstreamLocalGitBranch, rebasedLocalGitBranch);
 
 			rebasedLocalGitBranch = rebase(
 				true, upstreamLocalGitBranch, rebasedLocalGitBranch);
@@ -2660,32 +2661,45 @@ public class GitWorkingDirectory {
 			return localGitBranch;
 		}
 
-		checkoutLocalGitBranch(baseLocalGitBranch);
-
-		reset("--hard " + baseLocalGitBranch.getSHA());
-
 		String rebaseCommand = JenkinsResultsParserUtil.combine(
 			"git rebase ", baseLocalGitBranch.getName(), " ",
 			localGitBranch.getName());
 
-		GitUtil.ExecutionResult executionResult = executeBashCommands(
-			GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
-			1000 * 60 * 10, rebaseCommand);
+		for (int deepenAttempt = 0;; deepenAttempt++) {
+			checkoutLocalGitBranch(baseLocalGitBranch);
 
-		if (executionResult.getExitValue() != 0) {
+			reset("--hard " + baseLocalGitBranch.getSHA());
+
+			GitUtil.ExecutionResult executionResult = executeBashCommands(
+				GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
+				1000 * 60 * 10, rebaseCommand);
+
+			if (executionResult.getExitValue() == 0) {
+				return getCurrentLocalGitBranch();
+			}
+
 			if (abortOnFail) {
 				rebaseAbort();
 			}
 
-			throw new GitWorkingDirectoryRuntimeException(
-				this,
-				JenkinsResultsParserUtil.combine(
-					"Unable to rebase ", localGitBranch.getName(), " to ",
-					baseLocalGitBranch.getName(), "\n",
-					executionResult.getStandardError()));
-		}
+			long deepenStepSizeMillis =
+				_DEEPEN_STEP_SIZE_MILLIS << deepenAttempt;
 
-		return getCurrentLocalGitBranch();
+			Date shallowSinceDate = new Date(
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					deepenStepSizeMillis);
+
+			if (!abortOnFail || (deepenAttempt >= _DEEPEN_MAX_ATTEMPTS) ||
+				!deepenLocalGitBranch(baseLocalGitBranch, shallowSinceDate)) {
+
+				throw new GitWorkingDirectoryRuntimeException(
+					this,
+					JenkinsResultsParserUtil.combine(
+						"Unable to rebase ", localGitBranch.getName(), " to ",
+						baseLocalGitBranch.getName(), "\n",
+						executionResult.getStandardError()));
+			}
+		}
 	}
 
 	public void rebaseAbort() {
@@ -3614,14 +3628,14 @@ public class GitWorkingDirectory {
 
 	private static final int _BRANCHES_DELETE_BATCH_SIZE = 5;
 
+	private static final int _DEEPEN_MAX_ATTEMPTS = 5;
+
+	private static final long _DEEPEN_STEP_SIZE_MILLIS =
+		1000L * 60L * 60L * 24L * 30L;
+
 	private static final String _GIT_COMMIT_LOG_SEPARATOR = "\u0000";
 
 	private static final String _GIT_COMMIT_LOG_SEPARATOR_FORMAT = "%x00";
-
-	private static final int _MERGE_BASE_DEEPEN_MAX_ATTEMPTS = 5;
-
-	private static final long _MERGE_BASE_DEEPEN_STEP_SIZE_MILLIS =
-		1000L * 60L * 60L * 24L * 30L;
 
 	private static final Pattern _badRefPattern = Pattern.compile(
 		"fatal: bad object (?<badRef>.+/HEAD)");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -1555,10 +1555,6 @@ public class GitWorkingDirectory {
 			return getUpstreamLocalGitBranch();
 		}
 
-		if (!localGitBranchExists(branchName)) {
-			return null;
-		}
-
 		return _getLocalGitBranch(branchName, required);
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -795,13 +795,15 @@ public class GitWorkingDirectory {
 				fetch(null, noTags, gitHubDevRemoteGitBranch);
 
 				if (localSHAExists(remoteGitRefSHA)) {
-					if (localGitBranch != null) {
+					if (localGitBranch == null) {
 						return createLocalGitBranch(
-							localGitBranch.getName(), true, remoteGitRefSHA,
+							remoteGitRef.getName(), true, remoteGitRefSHA,
 							sourceRemoteGitBranch);
 					}
 
-					return null;
+					return createLocalGitBranch(
+						localGitBranch.getName(), true, remoteGitRefSHA,
+						sourceRemoteGitBranch);
 				}
 			}
 		}
@@ -929,7 +931,13 @@ public class GitWorkingDirectory {
 			}
 		}
 
-		if (localSHAExists(remoteGitRefSHA) && (localGitBranch != null)) {
+		if (localSHAExists(remoteGitRefSHA)) {
+			if (localGitBranch == null) {
+				return createLocalGitBranch(
+					remoteGitRef.getName(), true, remoteGitRefSHA,
+					sourceRemoteGitBranch);
+			}
+
 			return createLocalGitBranch(
 				localGitBranch.getName(), true, remoteGitRefSHA,
 				sourceRemoteGitBranch);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -1747,16 +1747,11 @@ public class GitWorkingDirectory {
 			return "";
 		}
 
-		executeBashCommands(
-			GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
-			GitUtil.MILLIS_TIMEOUT,
-			JenkinsResultsParserUtil.combine(
-				"git fetch ", upstreamGitRemote.getName(), " master"));
+		RemoteGitBranch upstreamMasterRemoteGitBranch = getRemoteGitBranch(
+			"master", upstreamGitRemote, true);
 
 		return getMergeBaseCommitSHA(
-			getCurrentBranchName(),
-			JenkinsResultsParserUtil.combine(
-				upstreamGitRemote.getName(), "/master"));
+			getCurrentLocalGitBranch(), fetch(upstreamMasterRemoteGitBranch));
 	}
 
 	public List<File> getModifiedDirsList(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -1572,10 +1572,17 @@ public class GitWorkingDirectory {
 
 		if (branchName != null) {
 			try {
+				RemoteGitBranch upstreamRemoteGitBranch = null;
+
+				if (branchName.equals(upstreamBranchName)) {
+					upstreamRemoteGitBranch = getUpstreamRemoteGitBranch();
+				}
+
 				return Arrays.asList(
 					GitBranchFactory.newLocalGitBranch(
 						localGitRepository, branchName,
-						getLocalGitBranchSHA(branchName)));
+						getLocalGitBranchSHA(branchName),
+						upstreamRemoteGitBranch));
 			}
 			catch (Exception exception) {
 				if (!branchName.equals(upstreamBranchName)) {
@@ -1601,10 +1608,17 @@ public class GitWorkingDirectory {
 				continue;
 			}
 
+			RemoteGitBranch remoteGitBranch = null;
+
+			if (localGitBranchName.equals(upstreamBranchName)) {
+				remoteGitBranch = getUpstreamRemoteGitBranch();
+			}
+
 			localGitBranches.add(
 				GitBranchFactory.newLocalGitBranch(
 					localGitRepository, localGitBranchName,
-					localGitBranchesShaMap.get(localGitBranchName)));
+					localGitBranchesShaMap.get(localGitBranchName),
+					remoteGitBranch));
 		}
 
 		return localGitBranches;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -442,6 +442,18 @@ public class GitWorkingDirectory {
 		return createLocalGitBranchRetryable.executeWithRetries();
 	}
 
+	public LocalGitBranch createLocalGitBranch(
+		String localGitBranchName, boolean force, String startPoint,
+		RemoteGitBranch sourceRemoteGitBranch) {
+
+		LocalGitBranch localGitBranch = createLocalGitBranch(
+			localGitBranchName, force, startPoint);
+
+		return GitBranchFactory.newLocalGitBranch(
+			localGitBranch.getLocalGitRepository(), localGitBranch.getName(),
+			localGitBranch.getSHA(), sourceRemoteGitBranch);
+	}
+
 	public String createPullRequest(
 		final String body, final String pullRequestBranchName,
 		final String receiverUserName, final String senderUserName,
@@ -711,6 +723,12 @@ public class GitWorkingDirectory {
 
 		String remoteGitRefSHA = remoteGitRef.getSHA();
 
+		RemoteGitBranch sourceRemoteGitBranch = null;
+
+		if (remoteGitRef instanceof RemoteGitBranch) {
+			sourceRemoteGitBranch = (RemoteGitBranch)remoteGitRef;
+		}
+
 		if ((shallowSinceDate == null) && localSHAExists(remoteGitRefSHA)) {
 			System.out.println(
 				remoteGitRefSHA + " already exists in Git repository");
@@ -723,11 +741,13 @@ public class GitWorkingDirectory {
 
 			if (localGitBranch == null) {
 				return createLocalGitBranch(
-					remoteGitRef.getName(), true, remoteGitRefSHA);
+					remoteGitRef.getName(), true, remoteGitRefSHA,
+					sourceRemoteGitBranch);
 			}
 
 			return createLocalGitBranch(
-				localGitBranch.getName(), true, remoteGitRefSHA);
+				localGitBranch.getName(), true, remoteGitRefSHA,
+				sourceRemoteGitBranch);
 		}
 
 		StringBuilder gitBranchesSHAReportStringBuilder = new StringBuilder();
@@ -760,7 +780,8 @@ public class GitWorkingDirectory {
 				if (localSHAExists(remoteGitRefSHA)) {
 					if (localGitBranch != null) {
 						return createLocalGitBranch(
-							localGitBranch.getName(), true, remoteGitRefSHA);
+							localGitBranch.getName(), true, remoteGitRefSHA,
+							sourceRemoteGitBranch);
 					}
 
 					return null;
@@ -893,7 +914,8 @@ public class GitWorkingDirectory {
 
 		if (localSHAExists(remoteGitRefSHA) && (localGitBranch != null)) {
 			return createLocalGitBranch(
-				localGitBranch.getName(), true, remoteGitRefSHA);
+				localGitBranch.getName(), true, remoteGitRefSHA,
+				sourceRemoteGitBranch);
 		}
 
 		return null;
@@ -1606,19 +1628,58 @@ public class GitWorkingDirectory {
 			sb.append(localGitBranch.getName());
 		}
 
-		GitUtil.ExecutionResult executionResult = executeBashCommands(
-			GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
-			GitUtil.MILLIS_TIMEOUT, sb.toString());
+		String command = sb.toString();
 
-		if (executionResult.getExitValue() != 0) {
-			throw new GitWorkingDirectoryRuntimeException(
-				this,
+		for (int deepenAttempt = 0;; deepenAttempt++) {
+			GitUtil.ExecutionResult executionResult = executeBashCommands(
+				GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
+				GitUtil.MILLIS_TIMEOUT, command);
+
+			if (executionResult.getExitValue() == 0) {
+				return executionResult.getStandardOut();
+			}
+
+			boolean canDeepen = false;
+
+			for (LocalGitBranch localGitBranch : localGitBranches) {
+				if (localGitBranch.getSourceRemoteGitBranch() != null) {
+					canDeepen = true;
+
+					break;
+				}
+			}
+
+			if (!canDeepen ||
+				(deepenAttempt >= _MERGE_BASE_DEEPEN_MAX_ATTEMPTS)) {
+
+				throw new GitWorkingDirectoryRuntimeException(
+					this,
+					JenkinsResultsParserUtil.combine(
+						"Unable to get merge base commit SHA\n",
+						executionResult.getStandardError()));
+			}
+
+			Date shallowSinceDate = new Date(
+				JenkinsResultsParserUtil.getCurrentTimeMillis() -
+					(_MERGE_BASE_DEEPEN_STEP_SIZE_MILLIS << deepenAttempt));
+
+			System.out.println(
 				JenkinsResultsParserUtil.combine(
-					"Unable to get merge base commit SHA\n",
-					executionResult.getStandardError()));
-		}
+					"WARNING: No merge base found within the local shallow ",
+					"horizon. Deepening to ",
+					JenkinsResultsParserUtil.toDateString(
+						shallowSinceDate, "yyyy-MM-dd'T'HH:mm:ss'Z'", "UTC"),
+					" and retrying."));
 
-		return executionResult.getStandardOut();
+			for (LocalGitBranch localGitBranch : localGitBranches) {
+				RemoteGitBranch sourceRemoteGitBranch =
+					localGitBranch.getSourceRemoteGitBranch();
+
+				if (sourceRemoteGitBranch != null) {
+					fetch(sourceRemoteGitBranch, shallowSinceDate);
+				}
+			}
+		}
 	}
 
 	public String getMergeBaseCommitSHA(String... refNames) {
@@ -1863,14 +1924,14 @@ public class GitWorkingDirectory {
 				checkoutLocalGitBranch(tempLocalGitBranch);
 			}
 
+			RemoteGitBranch senderRemoteGitBranch = getRemoteGitBranch(
+				senderBranchName, senderRemoteURL, true);
+
 			if (localSHAExists(senderSHA)) {
 				createLocalGitBranch(senderBranchName, true, senderSHA);
 			}
 			else {
-				RemoteGitRef senderRemoteGitRef = getRemoteGitRef(
-					senderBranchName, senderRemoteURL, true);
-
-				fetch(senderRemoteGitRef);
+				fetch(senderRemoteGitBranch);
 			}
 
 			RemoteGitBranch upstreamRemoteGitBranch = getRemoteGitBranch(
@@ -1880,21 +1941,20 @@ public class GitWorkingDirectory {
 				upstreamBranchSHA = upstreamRemoteGitBranch.getSHA();
 			}
 
-			LocalGitBranch upstreamLocalGitBranch;
-
-			if (localSHAExists(upstreamBranchSHA)) {
-				upstreamLocalGitBranch = createLocalGitBranch(
-					upstreamBranchName, true, upstreamBranchSHA);
-			}
-			else {
+			if (!localSHAExists(upstreamBranchSHA)) {
 				fetch(upstreamRemoteGitBranch);
-
-				upstreamLocalGitBranch = createLocalGitBranch(
-					upstreamRemoteGitBranch.getName(), true, upstreamBranchSHA);
 			}
+
+			LocalGitBranch upstreamLocalGitBranch = createLocalGitBranch(
+				upstreamBranchName, true, upstreamBranchSHA,
+				upstreamRemoteGitBranch);
 
 			LocalGitBranch rebasedLocalGitBranch = createLocalGitBranch(
-				rebasedLocalGitBranchName, true, senderSHA);
+				rebasedLocalGitBranchName, true, senderSHA,
+				senderRemoteGitBranch);
+
+			getMergeBaseCommitSHA(
+				upstreamLocalGitBranch, rebasedLocalGitBranch);
 
 			rebasedLocalGitBranch = rebase(
 				true, upstreamLocalGitBranch, rebasedLocalGitBranch);
@@ -3551,6 +3611,11 @@ public class GitWorkingDirectory {
 	private static final String _GIT_COMMIT_LOG_SEPARATOR = "\u0000";
 
 	private static final String _GIT_COMMIT_LOG_SEPARATOR_FORMAT = "%x00";
+
+	private static final int _MERGE_BASE_DEEPEN_MAX_ATTEMPTS = 5;
+
+	private static final long _MERGE_BASE_DEEPEN_STEP_SIZE_MILLIS =
+		1000L * 60L * 60L * 24L * 30L;
 
 	private static final Pattern _badRefPattern = Pattern.compile(
 		"fatal: bad object (?<badRef>.+/HEAD)");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -2674,45 +2674,33 @@ public class GitWorkingDirectory {
 			return localGitBranch;
 		}
 
-		String rebaseCommand = JenkinsResultsParserUtil.combine(
-			"git rebase ", baseLocalGitBranch.getName(), " ",
-			localGitBranch.getName());
+		getMergeBaseCommitSHA(baseLocalGitBranch, localGitBranch);
 
-		for (int deepenAttempt = 0;; deepenAttempt++) {
-			checkoutLocalGitBranch(baseLocalGitBranch);
+		checkoutLocalGitBranch(baseLocalGitBranch);
 
-			reset("--hard " + baseLocalGitBranch.getSHA());
+		reset("--hard " + baseLocalGitBranch.getSHA());
 
-			GitUtil.ExecutionResult executionResult = executeBashCommands(
-				GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
-				1000 * 60 * 10, rebaseCommand);
+		GitUtil.ExecutionResult executionResult = executeBashCommands(
+			GitUtil.RETRIES_SIZE_MAX, GitUtil.MILLIS_RETRY_DELAY,
+			1000 * 60 * 10,
+			JenkinsResultsParserUtil.combine(
+				"git rebase ", baseLocalGitBranch.getName(), " ",
+				localGitBranch.getName()));
 
-			if (executionResult.getExitValue() == 0) {
-				return getCurrentLocalGitBranch();
-			}
-
-			if (abortOnFail) {
-				rebaseAbort();
-			}
-
-			long deepenStepSizeMillis =
-				_DEEPEN_STEP_SIZE_MILLIS << deepenAttempt;
-
-			Date shallowSinceDate = new Date(
-				JenkinsResultsParserUtil.getCurrentTimeMillis() -
-					deepenStepSizeMillis);
-
-			if (!abortOnFail || (deepenAttempt >= _DEEPEN_MAX_ATTEMPTS) ||
-				!deepenLocalGitBranch(baseLocalGitBranch, shallowSinceDate)) {
-
-				throw new GitWorkingDirectoryRuntimeException(
-					this,
-					JenkinsResultsParserUtil.combine(
-						"Unable to rebase ", localGitBranch.getName(), " to ",
-						baseLocalGitBranch.getName(), "\n",
-						executionResult.getStandardError()));
-			}
+		if (executionResult.getExitValue() == 0) {
+			return getCurrentLocalGitBranch();
 		}
+
+		if (abortOnFail) {
+			rebaseAbort();
+		}
+
+		throw new GitWorkingDirectoryRuntimeException(
+			this,
+			JenkinsResultsParserUtil.combine(
+				"Unable to rebase ", localGitBranch.getName(), " to ",
+				baseLocalGitBranch.getName(), "\n",
+				executionResult.getStandardError()));
 	}
 
 	public void rebaseAbort() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -425,8 +425,15 @@ public class GitWorkingDirectory {
 	}
 
 	public LocalGitBranch createLocalGitBranch(
+		String localGitBranchName, boolean force, String startPoint) {
+
+		return createLocalGitBranch(
+			localGitBranchName, force, startPoint, null);
+	}
+
+	public LocalGitBranch createLocalGitBranch(
 		final String localGitBranchName, final boolean force,
-		final String startPoint) {
+		final String startPoint, final RemoteGitBranch sourceRemoteGitBranch) {
 
 		Retryable<LocalGitBranch> createLocalGitBranchRetryable =
 			new Retryable<LocalGitBranch>(true, 3, 0, true) {
@@ -434,24 +441,13 @@ public class GitWorkingDirectory {
 				@Override
 				public LocalGitBranch execute() {
 					return _createLocalGitBranch(
-						localGitBranchName, force, startPoint);
+						localGitBranchName, force, startPoint,
+						sourceRemoteGitBranch);
 				}
 
 			};
 
 		return createLocalGitBranchRetryable.executeWithRetries();
-	}
-
-	public LocalGitBranch createLocalGitBranch(
-		String localGitBranchName, boolean force, String startPoint,
-		RemoteGitBranch sourceRemoteGitBranch) {
-
-		LocalGitBranch localGitBranch = createLocalGitBranch(
-			localGitBranchName, force, startPoint);
-
-		return GitBranchFactory.newLocalGitBranch(
-			localGitBranch.getLocalGitRepository(), localGitBranch.getName(),
-			localGitBranch.getSHA(), sourceRemoteGitBranch);
 	}
 
 	public String createPullRequest(
@@ -3192,7 +3188,8 @@ public class GitWorkingDirectory {
 	}
 
 	private LocalGitBranch _createLocalGitBranch(
-		String localGitBranchName, boolean force, String startPoint) {
+		String localGitBranchName, boolean force, String startPoint,
+		RemoteGitBranch sourceRemoteGitBranch) {
 
 		if (JenkinsResultsParserUtil.isNullOrEmpty(localGitBranchName)) {
 			throw new GitWorkingDirectoryRuntimeException(
@@ -3260,7 +3257,16 @@ public class GitWorkingDirectory {
 				"Created local branch ", localGitBranchName, " at ",
 				startPoint));
 
-		return getLocalGitBranch(localGitBranchName, true);
+		LocalGitBranch localGitBranch = getLocalGitBranch(
+			localGitBranchName, true);
+
+		if (sourceRemoteGitBranch == null) {
+			return localGitBranch;
+		}
+
+		return GitBranchFactory.newLocalGitBranch(
+			localGitBranch.getLocalGitRepository(), localGitBranch.getName(),
+			localGitBranch.getSHA(), sourceRemoteGitBranch);
 	}
 
 	private boolean _deleteLocalGitBranches(String... branchNames) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitBranch.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/LocalGitBranch.java
@@ -7,6 +7,8 @@ package com.liferay.jenkins.results.parser;
 
 import java.io.File;
 
+import java.util.List;
+
 /**
  * @author Michael Hashimoto
  */
@@ -26,6 +28,24 @@ public class LocalGitBranch extends BaseGitRef {
 
 	public LocalGitRepository getLocalGitRepository() {
 		return _localGitRepository;
+	}
+
+	public RemoteGitBranch getSourceRemoteGitBranch() {
+		if (_sourceRemoteGitBranch == null) {
+			return null;
+		}
+
+		GitWorkingDirectory gitWorkingDirectory = getGitWorkingDirectory();
+
+		List<String> branchNamesContainingSHA =
+			gitWorkingDirectory.getBranchNamesContainingSHA(
+				_sourceRemoteGitBranch.getSHA());
+
+		if (!branchNamesContainingSHA.contains(getName())) {
+			return null;
+		}
+
+		return _sourceRemoteGitBranch;
 	}
 
 	public String getUpstreamBranchName() {
@@ -53,6 +73,13 @@ public class LocalGitBranch extends BaseGitRef {
 	protected LocalGitBranch(
 		LocalGitRepository localGitRepository, String name, String sha) {
 
+		this(localGitRepository, name, sha, null);
+	}
+
+	protected LocalGitBranch(
+		LocalGitRepository localGitRepository, String name, String sha,
+		RemoteGitBranch sourceRemoteGitBranch) {
+
 		super(name, sha);
 
 		if (localGitRepository == null) {
@@ -60,8 +87,11 @@ public class LocalGitBranch extends BaseGitRef {
 		}
 
 		_localGitRepository = localGitRepository;
+
+		_sourceRemoteGitBranch = sourceRemoteGitBranch;
 	}
 
 	private final LocalGitRepository _localGitRepository;
+	private final RemoteGitBranch _sourceRemoteGitBranch;
 
 }

--- a/modules/util.gradle
+++ b/modules/util.gradle
@@ -15,7 +15,7 @@ buildscript {
 	apply from: file("build-buildscript.gradle"), to: buildscript
 
 	dependencies {
-		classpath group: "com.liferay", name: "com.liferay.jenkins.results.parser", version: "1.0.1827"
+		classpath group: "com.liferay", name: "com.liferay.jenkins.results.parser", version: "1.0.1828"
 	}
 }
 


### PR DESCRIPTION
## Summary

- Rewrites the generic `poshi-migrate` skill so any team can use it without AC-specific assumptions. Layered with personal overrides via per-developer skills under `~/.claude/skills`.
- Untracks `config.json` so each developer keeps their own (`componentPlaywrightModules`, `defaultComponentName`, …) and ships a `config.example.json` with the suggested defaults.
- Adds an interactive argument resolver: parses `test.properties` for the `@component-name` list, remembers the choice as `defaultComponentName`, then lists the first 20 matching `.testcase` files for the chosen component (with a free-text fallback at both prompts).
- New Phase 0 (Feasibility) gates blocked tests upfront. Phase 3 adds the API-First Setup Substitution decision tree, State Reset, Cascading Fixtures and the Tagging policy. Phase 4 adds the failure protocol; Output reports skipped tests with proposed unblockers.

## Test Plan

- [ ] Run `/poshi-migrate` with no argument and confirm the prompt offers the `test.properties` component list plus the "Other" fallback.
- [ ] Pick a component, confirm the choice is persisted to `config.json`.
- [ ] Confirm a second invocation suggests the saved default and lets you change it.
- [ ] Confirm `.gitignore` keeps `config.json` out of the diff while `config.example.json` is committed.