### PR TITLE
LPD-93970 Add basic postgresql support to worktree hooks

### DIFF
--- a/.claude/hooks/_common.sh
+++ b/.claude/hooks/_common.sh
@@ -38,37 +38,6 @@ function _die {
 	exit 1
 }
 
-function _drop_database {
-	local worktree_path="${1}"
-	local bundles_dir="${2:-}"
-
-	command -v mysql >/dev/null 2>&1 || return 0
-
-	local db_name
-
-	db_name="$(_derive_db_name "$(basename "${worktree_path}")")"
-
-	[[ ${db_name} != lportal ]] || return 0
-
-	local user=root
-	local password=""
-
-	if [[ -n ${bundles_dir} ]]
-	then
-		user="$(_get_property_from_files "jdbc\.default\.username" root "${bundles_dir}/portal-ext.properties" "${bundles_dir}/portal-setup-wizard.properties")"
-		password="$(_get_property_from_files "jdbc\.default\.password" "" "${bundles_dir}/portal-ext.properties" "${bundles_dir}/portal-setup-wizard.properties")"
-	fi
-
-	local mysql_args=(--user "${user}")
-
-	if [[ -n ${password} ]]
-	then
-		mysql_args+=(--password="${password}")
-	fi
-
-	mysql "${mysql_args[@]}" --execute "DROP DATABASE IF EXISTS ${db_name};" >&2 || true
-}
-
 function _find_app_server_parent_dir {
 	local project_dir="${1}"
 
@@ -148,4 +117,22 @@ function _get_property_from_files {
 	done
 
 	echo "${default}"
+}
+
+function _resolve_db_brand {
+	local brand
+
+	brand="$(echo "${WORKTREE_DB_BRAND:-mysql}" | tr "[:upper:]" "[:lower:]")"
+
+	case "${brand}" in
+		*psql*)
+			echo psql
+			;;
+		*mysql*)
+			echo mysql
+			;;
+		*)
+			_die "WORKTREE_DB_BRAND must contain \"mysql\" or \"psql\" (got \"${brand}\")."
+			;;
+	esac
 }

--- a/.claude/hooks/mysql.sh
+++ b/.claude/hooks/mysql.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+function _drop_database {
+	local worktree_path="${1}"
+	local bundles_dir="${2:-}"
+
+	command -v mysql >/dev/null 2>&1 || return 0
+
+	local db_name
+
+	db_name="$(_derive_db_name "$(basename "${worktree_path}")")"
+
+	[[ ${db_name} != lportal ]] || return 0
+
+	local user=root
+	local password=""
+
+	if [[ -n ${bundles_dir} ]]
+	then
+		user="$(_get_property_from_files "jdbc\.default\.username" root "${bundles_dir}/portal-ext.properties" "${bundles_dir}/portal-setup-wizard.properties")"
+		password="$(_get_property_from_files "jdbc\.default\.password" "" "${bundles_dir}/portal-ext.properties" "${bundles_dir}/portal-setup-wizard.properties")"
+	fi
+
+	local mysql_args=(--user "${user}")
+
+	if [[ -n ${password} ]]
+	then
+		mysql_args+=(--password="${password}")
+	fi
+
+	mysql "${mysql_args[@]}" --execute "DROP DATABASE IF EXISTS ${db_name};" >&2 || true
+}
+
+function _set_database {
+	local db_name
+
+	db_name="$(_derive_db_name "$(basename "${WORKTREE_DIR}")")"
+
+	local file="${BUNDLES_DIR}/portal-ext.properties"
+	local wizard_file="${BUNDLES_DIR}/portal-setup-wizard.properties"
+
+	local existing_user existing_password
+
+	existing_user="$(_get_property_from_files "jdbc\.default\.username" root "${file}" "${wizard_file}")"
+	existing_password="$(_get_property_from_files "jdbc\.default\.password" "" "${file}" "${wizard_file}")"
+
+	_set_property "${file}" jdbc.default.driverClassName com.mysql.cj.jdbc.Driver
+	_set_property "${file}" jdbc.default.url "jdbc:mysql://localhost/${db_name}?characterEncoding=UTF-8&dontTrackOpenResources=true&holdResultsOpenOverStatementClose=true&serverTimezone=GMT&useFastDateParsing=false&useUnicode=true"
+	_set_property "${file}" jdbc.default.username "${existing_user}"
+	_set_property "${file}" jdbc.default.password "${existing_password}"
+
+	command -v mysql >/dev/null 2>&1 || return 0
+
+	local mysql_args=()
+
+	if [[ -n ${existing_password} ]]
+	then
+		mysql_args+=(--password="${existing_password}")
+	fi
+
+	mysql_args+=(--user "${existing_user}")
+
+	mysql "${mysql_args[@]}" --execute "CREATE DATABASE IF NOT EXISTS ${db_name} CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;" >&2 || true
+}

--- a/.claude/hooks/psql.sh
+++ b/.claude/hooks/psql.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+function _schema_name {
+	local db_name
+
+	db_name="$(_derive_db_name "$(basename "${1}")")"
+
+	[[ ${db_name} != lportal ]] || return 1
+
+	echo "${db_name#lportal_}"
+}
+
+function _psql_admin {
+	local dbname="${1}"
+
+	shift
+
+	psql --host localhost --username postgres --dbname "${dbname}" --no-psqlrc "${@}"
+}
+
+function _drop_database {
+	local worktree_path="${1}"
+
+	command -v psql >/dev/null 2>&1 || return 0
+
+	local name
+
+	name="$(_schema_name "${worktree_path}")" || return 0
+
+	_psql_admin postgres --command "DROP SCHEMA IF EXISTS \"${name}\" CASCADE" >&2 || true
+	_psql_admin postgres --command "DROP OWNED BY \"${name}\"" >&2 || true
+	_psql_admin postgres --command "DROP ROLE IF EXISTS \"${name}\"" >&2 || true
+}
+
+function _set_database {
+	local name
+
+	name="$(_schema_name "${WORKTREE_DIR}")" || return 0
+
+	local file="${BUNDLES_DIR}/portal-ext.properties"
+	local wizard_file="${BUNDLES_DIR}/portal-setup-wizard.properties"
+
+	local existing_password
+
+	existing_password="$(_get_property_from_files "jdbc\.default\.password" "" "${file}" "${wizard_file}")"
+
+	_set_property "${file}" jdbc.default.driverClassName org.postgresql.Driver
+	_set_property "${file}" jdbc.default.url "jdbc:postgresql://localhost/postgres?currentSchema=${name}"
+	_set_property "${file}" jdbc.default.username "${name}"
+	_set_property "${file}" jdbc.default.password "${existing_password}"
+
+	command -v psql >/dev/null 2>&1 || return 0
+
+	local create_role="CREATE ROLE \"${name}\" LOGIN"
+
+	if [[ -n ${existing_password} ]]
+	then
+		create_role="${create_role} PASSWORD '${existing_password}'"
+	fi
+
+	_psql_admin postgres --tuples-only --no-align --command "SELECT 1 FROM pg_roles WHERE rolname = '${name}'" | grep --quiet 1 ||
+		_psql_admin postgres --command "${create_role}" >&2 || true
+
+	_psql_admin postgres --command "CREATE SCHEMA IF NOT EXISTS \"${name}\" AUTHORIZATION \"${name}\"" >&2 || true
+}

--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -8,6 +8,8 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 source _common.sh
 
+source "$(_resolve_db_brand).sh"
+
 function main {
 	_create_worktree
 
@@ -215,38 +217,6 @@ function _set_data_guard_port {
 	_atomic_write "${file}" <<EOF
 port="${target}"
 EOF
-}
-
-function _set_database {
-	local db_name
-
-	db_name="$(_derive_db_name "$(basename "${WORKTREE_DIR}")")"
-
-	local file="${BUNDLES_DIR}/portal-ext.properties"
-	local wizard_file="${BUNDLES_DIR}/portal-setup-wizard.properties"
-
-	local existing_user existing_password
-
-	existing_user="$(_get_property_from_files "jdbc\.default\.username" root "${file}" "${wizard_file}")"
-	existing_password="$(_get_property_from_files "jdbc\.default\.password" "" "${file}" "${wizard_file}")"
-
-	_set_property "${file}" jdbc.default.driverClassName com.mysql.cj.jdbc.Driver
-	_set_property "${file}" jdbc.default.url "jdbc:mysql://localhost/${db_name}?characterEncoding=UTF-8&dontTrackOpenResources=true&holdResultsOpenOverStatementClose=true&serverTimezone=GMT&useFastDateParsing=false&useUnicode=true"
-	_set_property "${file}" jdbc.default.username "${existing_user}"
-	_set_property "${file}" jdbc.default.password "${existing_password}"
-
-	command -v mysql >/dev/null 2>&1 || return 0
-
-	local mysql_args=()
-
-	if [[ -n ${existing_password} ]]
-	then
-		mysql_args+=(--password="${existing_password}")
-	fi
-
-	mysql_args+=(--user "${existing_user}")
-
-	mysql "${mysql_args[@]}" --execute "CREATE DATABASE IF NOT EXISTS ${db_name} CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;" >&2 || true
 }
 
 function _set_debug_port {

--- a/.claude/hooks/worktree-remove.sh
+++ b/.claude/hooks/worktree-remove.sh
@@ -8,6 +8,8 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 source _common.sh
 
+source "$(_resolve_db_brand).sh"
+
 function main {
 	local bundles_dir=""
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93970

## What Is Being Fixed

The Claude worktree hooks only knew how to provision and tear down MySQL databases. Developers running a PostgreSQL bundle had no way to get a per-worktree database created and wired into portal-ext.properties, and the remove hook could not drop it.

## How It Is Being Fixed

The MySQL-specific logic was extracted out of _common.sh and worktree-create.sh into a dedicated mysql.sh, with no behavior change. A parallel psql.sh implements the same _set_database / _drop_database contract for PostgreSQL, provisioning a per-worktree role and schema and pointing the JDBC properties at the Postgres driver. A new _resolve_db_brand helper reads the WORKTREE_DB_BRAND environment variable (defaulting to mysql) and the create/remove hooks source the matching brand file, so the same hooks drive either backend.

## Why Are There No Tests?

These are local Claude worktree hook scripts and the repository has no test harness for them; the change was verified manually by running worktree create and remove against a PostgreSQL bundle.

## PR Check

**pr-check: PASS** — tested on `3ccec48a6c003c5cdb0f1f3b42ca495d8814cd38`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "3ccec48a6c003c5cdb0f1f3b42ca495d8814cd38"} -->