### PR TITLE
LPD-94071 Preserve CLAUDE Markdown files during git clean

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -89,6 +89,7 @@
         -e '!**/.classpath' \
         -e '!**/.project' \
         -e '!**/.settings' \
+        -e '!**/CLAUDE*.md' \
         -e '!*.*.properties' \
         -e '!.gradle' \
         -e '!.gradle/**/*' \


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94071

## What Is Being Fixed

The `build.git.clean.command` in `build.properties` runs `git clean -dfqX .` during `ant all` and `ant clean`. The `-X` flag removes Git-ignored files, and `CLAUDE.local.md` is gitignored, so every clean deleted local `CLAUDE*.md` instruction files used by Claude Code.

## How It Is Being Fixed

Added a `-e '!**/CLAUDE*.md'` exclusion to the clean command so any `CLAUDE*.md` file (for example `CLAUDE.md` or `CLAUDE.local.md`) at any directory depth is preserved, matching the style of the existing exclusions.

## Why Are There No Tests?

This is a single-line change to a build-tooling configuration property; there is no automated test harness for `git clean` exclusion patterns. The behavior was verified manually with `git clean -dfXn` dry runs confirming the files are preserved.

## PR Check

**pr-check: PASS** — tested on `aa29cffdb01a29e3856c9867589f46fdd2b95ef3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "aa29cffdb01a29e3856c9867589f46fdd2b95ef3"} -->
