### PR TITLE
LPD-96329 Allow test.step for large Playwright tests in the rules

### DIFF
--- a/.claude/rules/playwright.md
+++ b/.claude/rules/playwright.md
@@ -52,7 +52,7 @@ test('does something', {tag: '@LPD-12345'}, async ({apiHelpers, myPage, page}) =
 
 **Always tag the test with the LPD ticket** it covers: `{tag: '@LPD-XXXXX'}`. This is mandatory — it is how tests are linked back to Jira. Pass an array when a single test covers more than one ticket: `{tag: ['@LPD-12345', '@LPD-67890']}`.
 
-Break the body of a test into phases with single-line comments (`// Add fields`, `// Publish the structure`, `// Check validation`) so the flow reads top-down. Do not narrate each statement — the comments mark sections, not lines.
+Break the body of a test into phases with single-line comments (`// Add fields`, `// Publish the structure`, `// Check validation`) so the flow reads top-down. Do not narrate each statement — the comments mark sections, not lines. For a large test where named phases in the trace and HTML report would aid debugging, wrap each phase in `test.step('Add fields', async () => {...})` instead — same intent, but the phase names surface as collapsible steps when a run fails.
 
 Generate unique names with `getRandomInt` / `getRandomString` from `modules/test/playwright/utils` for anything that must not collide across parallel runs (structure labels, names, ERCs, etc.). Tests share an environment; hardcoded names flake.
 


### PR DESCRIPTION
### What Is Being Changed

The Playwright testing rule in `.claude/rules/playwright.md` previously sanctioned a single way to break a test body into phases: single-line comments (`// Add fields`, `// Publish the structure`). For large, multi-phase tests this leaves the Playwright trace and HTML report without named phases, so when a long test fails there is no structural signal pointing at which phase broke.

### How Is Being Changed

The rule now keeps single-line comments as the default for small tests and adds an explicit allowance: for a large test where named phases would aid debugging, wrap each phase in `test.step('...', async () => {...})`. The intent is the same — mark sections, not lines — but the phase names then surface as collapsible steps in the trace and the HTML report when a run fails. This is consistent with existing usage, since `test.step()` already appears across many specs in the repo.

### Tests

This is a documentation-only change to a Claude rule file; there is no runtime behavior to cover with an automated test. `pr-check` was run and the only matched validation, Source Format, passed with no changes.

cc @sandrodw3
