### PR TITLE
LPD-94433 Extract overridable getGraphQLField in REST test cases

### DIFF
--- a/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/resource/v1_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/resource/v1_0/test/BaseChannelResourceTestCase.java
@@ -425,17 +425,8 @@ public abstract class BaseChannelResourceTestCase {
 
 	@Test
 	public void testGraphQLGetChannelsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"channels",
-			new HashMap<String, Object>() {
-				{
-					put("keywords", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetChannelsPageChannel_getGraphQLField();
 
 		// No namespace
 
@@ -484,6 +475,22 @@ public abstract class BaseChannelResourceTestCase {
 			channel2,
 			Arrays.asList(
 				ChannelSerDes.toDTOs(channelsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField testGraphQLGetChannelsPageChannel_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"channels",
+			new HashMap<String, Object>() {
+				{
+					put("keywords", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -1434,4 +1441,4 @@ public abstract class BaseChannelResourceTestCase {
 		_channelResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-292905265
+// LIFERAY-REST-BUILDER-HASH:1665399309

--- a/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseCTCollectionResourceTestCase.java
+++ b/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseCTCollectionResourceTestCase.java
@@ -1366,17 +1366,8 @@ public abstract class BaseCTCollectionResourceTestCase {
 
 	@Test
 	public void testGraphQLGetCTCollectionsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"cTCollections",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetCTCollectionsPageCTCollection_getGraphQLField();
 
 		// No namespace
 
@@ -1431,6 +1422,23 @@ public abstract class BaseCTCollectionResourceTestCase {
 			Arrays.asList(
 				CTCollectionSerDes.toDTOs(
 					cTCollectionsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetCTCollectionsPageCTCollection_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"cTCollections",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3060,4 +3068,4 @@ public abstract class BaseCTCollectionResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1928810216
+// LIFERAY-REST-BUILDER-HASH:-2134770516

--- a/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseCTRemoteResourceTestCase.java
+++ b/modules/apps/change-tracking/change-tracking-rest-test/src/testIntegration/java/com/liferay/change/tracking/rest/resource/v1_0/test/BaseCTRemoteResourceTestCase.java
@@ -908,17 +908,8 @@ public abstract class BaseCTRemoteResourceTestCase {
 
 	@Test
 	public void testGraphQLGetCTRemotesPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"cTRemotes",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetCTRemotesPageCTRemote_getGraphQLField();
 
 		// No namespace
 
@@ -967,6 +958,22 @@ public abstract class BaseCTRemoteResourceTestCase {
 			ctRemote2,
 			Arrays.asList(
 				CTRemoteSerDes.toDTOs(cTRemotesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField testGraphQLGetCTRemotesPageCTRemote_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"cTRemotes",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2355,4 +2362,4 @@ public abstract class BaseCTRemoteResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1137224183
+// LIFERAY-REST-BUILDER-HASH:-210878787

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -1372,17 +1372,8 @@ public abstract class BaseAccountResourceTestCase {
 
 	@Test
 	public void testGraphQLGetAccountsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"accounts",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAccountsPageAccount_getGraphQLField();
 
 		// No namespace
 
@@ -1432,6 +1423,22 @@ public abstract class BaseAccountResourceTestCase {
 			account2,
 			Arrays.asList(
 				AccountSerDes.toDTOs(accountsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField testGraphQLGetAccountsPageAccount_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"accounts",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2965,4 +2972,4 @@ public abstract class BaseAccountResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-245737954
+// LIFERAY-REST-BUILDER-HASH:-1118207494

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCatalogResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCatalogResourceTestCase.java
@@ -1257,17 +1257,8 @@ public abstract class BaseCatalogResourceTestCase {
 
 	@Test
 	public void testGraphQLGetCatalogsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"catalogs",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetCatalogsPageCatalog_getGraphQLField();
 
 		// No namespace
 
@@ -1317,6 +1308,22 @@ public abstract class BaseCatalogResourceTestCase {
 			catalog2,
 			Arrays.asList(
 				CatalogSerDes.toDTOs(catalogsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField testGraphQLGetCatalogsPageCatalog_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"catalogs",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2973,4 +2980,4 @@ public abstract class BaseCatalogResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1820977679
+// LIFERAY-REST-BUILDER-HASH:754594411

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCurrencyResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCurrencyResourceTestCase.java
@@ -839,17 +839,8 @@ public abstract class BaseCurrencyResourceTestCase {
 
 	@Test
 	public void testGraphQLGetCurrenciesPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"currencies",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetCurrenciesPageCurrency_getGraphQLField();
 
 		// No namespace
 
@@ -903,6 +894,23 @@ public abstract class BaseCurrencyResourceTestCase {
 			Arrays.asList(
 				CurrencySerDes.toDTOs(
 					currenciesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetCurrenciesPageCurrency_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"currencies",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2685,4 +2693,4 @@ public abstract class BaseCurrencyResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:928659869
+// LIFERAY-REST-BUILDER-HASH:-2070873009

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseListTypeDefinitionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseListTypeDefinitionResourceTestCase.java
@@ -384,15 +384,9 @@ public abstract class BaseListTypeDefinitionResourceTestCase {
 
 		Long id = testGetSpecificationIdListTypeDefinitionsPage_getId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"specificationIdListTypeDefinitions",
-			new HashMap<String, Object>() {
-				{
-					put("id", id);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSpecificationIdListTypeDefinitionsPageSpecificationListTypeDefinition_getGraphQLField(
+				id);
 
 		// No namespace
 
@@ -461,6 +455,22 @@ public abstract class BaseListTypeDefinitionResourceTestCase {
 				ListTypeDefinitionSerDes.toDTOs(
 					specificationIdListTypeDefinitionsJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSpecificationIdListTypeDefinitionsPageSpecificationListTypeDefinition_getGraphQLField(
+				Long id)
+		throws Exception {
+
+		return new GraphQLField(
+			"specificationIdListTypeDefinitions",
+			new HashMap<String, Object>() {
+				{
+					put("id", id);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected ListTypeDefinition
@@ -1642,4 +1652,4 @@ public abstract class BaseListTypeDefinitionResourceTestCase {
 		ListTypeDefinitionResource _listTypeDefinitionResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1465061306
+// LIFERAY-REST-BUILDER-HASH:-91630562

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionCategoryResourceTestCase.java
@@ -918,16 +918,8 @@ public abstract class BaseOptionCategoryResourceTestCase {
 
 	@Test
 	public void testGraphQLGetOptionCategoriesPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"optionCategories",
-			new HashMap<String, Object>() {
-				{
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetOptionCategoriesPageOptionCategory_getGraphQLField();
 
 		// No namespace
 
@@ -983,6 +975,22 @@ public abstract class BaseOptionCategoryResourceTestCase {
 			Arrays.asList(
 				OptionCategorySerDes.toDTOs(
 					optionCategoriesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetOptionCategoriesPageOptionCategory_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"optionCategories",
+			new HashMap<String, Object>() {
+				{
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2637,4 +2645,4 @@ public abstract class BaseOptionCategoryResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1502872318
+// LIFERAY-REST-BUILDER-HASH:2145626966

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionResourceTestCase.java
@@ -1245,17 +1245,8 @@ public abstract class BaseOptionResourceTestCase {
 
 	@Test
 	public void testGraphQLGetOptionsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"options",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetOptionsPageOption_getGraphQLField();
 
 		// No namespace
 
@@ -1305,6 +1296,22 @@ public abstract class BaseOptionResourceTestCase {
 			option2,
 			Arrays.asList(
 				OptionSerDes.toDTOs(optionsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField testGraphQLGetOptionsPageOption_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"options",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2609,4 +2616,4 @@ public abstract class BaseOptionResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-523112708
+// LIFERAY-REST-BUILDER-HASH:-1633143976

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductConfigurationListResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductConfigurationListResourceTestCase.java
@@ -1480,17 +1480,8 @@ public abstract class BaseProductConfigurationListResourceTestCase {
 
 	@Test
 	public void testGraphQLGetProductConfigurationListsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"productConfigurationLists",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetProductConfigurationListsPageProductConfigurationList_getGraphQLField();
 
 		// No namespace
 
@@ -1552,6 +1543,23 @@ public abstract class BaseProductConfigurationListResourceTestCase {
 			Arrays.asList(
 				ProductConfigurationListSerDes.toDTOs(
 					productConfigurationListsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetProductConfigurationListsPageProductConfigurationList_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"productConfigurationLists",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3160,4 +3168,4 @@ public abstract class BaseProductConfigurationListResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:278589690
+// LIFERAY-REST-BUILDER-HASH:309415702

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupResourceTestCase.java
@@ -1336,17 +1336,8 @@ public abstract class BaseProductGroupResourceTestCase {
 
 	@Test
 	public void testGraphQLGetProductGroupsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"productGroups",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetProductGroupsPageProductGroup_getGraphQLField();
 
 		// No namespace
 
@@ -1402,6 +1393,23 @@ public abstract class BaseProductGroupResourceTestCase {
 			Arrays.asList(
 				ProductGroupSerDes.toDTOs(
 					productGroupsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetProductGroupsPageProductGroup_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"productGroups",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2554,4 +2562,4 @@ public abstract class BaseProductGroupResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:584019228
+// LIFERAY-REST-BUILDER-HASH:206026064

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
@@ -1763,17 +1763,8 @@ public abstract class BaseProductResourceTestCase {
 
 	@Test
 	public void testGraphQLGetProductsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"products",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetProductsPageProduct_getGraphQLField();
 
 		// No namespace
 
@@ -1823,6 +1814,22 @@ public abstract class BaseProductResourceTestCase {
 			product2,
 			Arrays.asList(
 				ProductSerDes.toDTOs(productsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField testGraphQLGetProductsPageProduct_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"products",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -4476,4 +4483,4 @@ public abstract class BaseProductResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1889484572
+// LIFERAY-REST-BUILDER-HASH:634991064

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSpecificationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSpecificationResourceTestCase.java
@@ -1356,17 +1356,8 @@ public abstract class BaseSpecificationResourceTestCase {
 
 	@Test
 	public void testGraphQLGetSpecificationsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"specifications",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSpecificationsPageSpecification_getGraphQLField();
 
 		// No namespace
 
@@ -1422,6 +1413,23 @@ public abstract class BaseSpecificationResourceTestCase {
 			Arrays.asList(
 				SpecificationSerDes.toDTOs(
 					specificationsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSpecificationsPageSpecification_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"specifications",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2779,4 +2787,4 @@ public abstract class BaseSpecificationResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-537257451
+// LIFERAY-REST-BUILDER-HASH:-946427203

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseChannelResourceTestCase.java
@@ -1397,17 +1397,8 @@ public abstract class BaseChannelResourceTestCase {
 
 	@Test
 	public void testGraphQLGetChannelsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"channels",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetChannelsPageChannel_getGraphQLField();
 
 		// No namespace
 
@@ -1457,6 +1448,22 @@ public abstract class BaseChannelResourceTestCase {
 			channel2,
 			Arrays.asList(
 				ChannelSerDes.toDTOs(channelsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField testGraphQLGetChannelsPageChannel_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"channels",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2929,4 +2936,4 @@ public abstract class BaseChannelResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:934595126
+// LIFERAY-REST-BUILDER-HASH:-1134979776

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseReplenishmentItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseReplenishmentItemResourceTestCase.java
@@ -1206,17 +1206,9 @@ public abstract class BaseReplenishmentItemResourceTestCase {
 	public void testGraphQLGetReplenishmentItemsPage() throws Exception {
 		String sku = testGetReplenishmentItemsPage_getSku();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"replenishmentItems",
-			new HashMap<String, Object>() {
-				{
-					put("sku", "\"" + sku + "\"");
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetReplenishmentItemsPageReplenishmentItem_getGraphQLField(
+				sku);
 
 		// No namespace
 
@@ -1274,6 +1266,24 @@ public abstract class BaseReplenishmentItemResourceTestCase {
 			Arrays.asList(
 				ReplenishmentItemSerDes.toDTOs(
 					replenishmentItemsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetReplenishmentItemsPageReplenishmentItem_getGraphQLField(
+				String sku)
+		throws Exception {
+
+		return new GraphQLField(
+			"replenishmentItems",
+			new HashMap<String, Object>() {
+				{
+					put("sku", "\"" + sku + "\"");
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected ReplenishmentItem
@@ -1488,17 +1498,9 @@ public abstract class BaseReplenishmentItemResourceTestCase {
 		Long warehouseId =
 			testGetWarehouseIdReplenishmentItemsPage_getWarehouseId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"warehouseIdReplenishmentItems",
-			new HashMap<String, Object>() {
-				{
-					put("warehouseId", warehouseId);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetWarehouseIdReplenishmentItemsPageReplenishmentItem_getGraphQLField(
+				warehouseId);
 
 		// No namespace
 
@@ -1564,6 +1566,24 @@ public abstract class BaseReplenishmentItemResourceTestCase {
 				ReplenishmentItemSerDes.toDTOs(
 					warehouseIdReplenishmentItemsJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetWarehouseIdReplenishmentItemsPageReplenishmentItem_getGraphQLField(
+				Long warehouseId)
+		throws Exception {
+
+		return new GraphQLField(
+			"warehouseIdReplenishmentItems",
+			new HashMap<String, Object>() {
+				{
+					put("warehouseId", warehouseId);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected ReplenishmentItem
@@ -2964,4 +2984,4 @@ public abstract class BaseReplenishmentItemResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-250795444
+// LIFERAY-REST-BUILDER-HASH:749594213

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseResourceTestCase.java
@@ -1010,17 +1010,8 @@ public abstract class BaseWarehouseResourceTestCase {
 
 	@Test
 	public void testGraphQLGetWarehousesPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"warehouses",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetWarehousesPageWarehouse_getGraphQLField();
 
 		// No namespace
 
@@ -1076,6 +1067,23 @@ public abstract class BaseWarehouseResourceTestCase {
 			Arrays.asList(
 				WarehouseSerDes.toDTOs(
 					warehousesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetWarehousesPageWarehouse_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"warehouses",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2718,4 +2726,4 @@ public abstract class BaseWarehouseResourceTestCase {
 		WarehouseResource _warehouseResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:814461372
+// LIFERAY-REST-BUILDER-HASH:739381314

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAttachmentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAttachmentResourceTestCase.java
@@ -1647,20 +1647,9 @@ public abstract class BaseAttachmentResourceTestCase {
 		String externalReferenceCode =
 			testGetOrderByExternalReferenceCodeAttachmentsPage_getExternalReferenceCode();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"orderByExternalReferenceCodeAttachments",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"externalReferenceCode",
-						"\"" + externalReferenceCode + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetOrderByExternalReferenceCodeAttachmentsPageOrderAttachment_getGraphQLField(
+				externalReferenceCode);
 
 		// No namespace
 
@@ -1731,6 +1720,27 @@ public abstract class BaseAttachmentResourceTestCase {
 				AttachmentSerDes.toDTOs(
 					orderByExternalReferenceCodeAttachmentsJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetOrderByExternalReferenceCodeAttachmentsPageOrderAttachment_getGraphQLField(
+				String externalReferenceCode)
+		throws Exception {
+
+		return new GraphQLField(
+			"orderByExternalReferenceCodeAttachments",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"externalReferenceCode",
+						"\"" + externalReferenceCode + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected Attachment
@@ -3263,4 +3273,4 @@ public abstract class BaseAttachmentResourceTestCase {
 			AttachmentResource _attachmentResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1282012896
+// LIFERAY-REST-BUILDER-HASH:-1023658281

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderResourceTestCase.java
@@ -1314,17 +1314,8 @@ public abstract class BaseOrderResourceTestCase {
 
 	@Test
 	public void testGraphQLGetOrdersPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"orders",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetOrdersPageOrder_getGraphQLField();
 
 		// No namespace
 
@@ -1374,6 +1365,22 @@ public abstract class BaseOrderResourceTestCase {
 			order2,
 			Arrays.asList(
 				OrderSerDes.toDTOs(ordersJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField testGraphQLGetOrdersPageOrder_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"orders",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -7183,4 +7190,4 @@ public abstract class BaseOrderResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1578638579
+// LIFERAY-REST-BUILDER-HASH:1209284355

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleResourceTestCase.java
@@ -1292,17 +1292,8 @@ public abstract class BaseOrderRuleResourceTestCase {
 
 	@Test
 	public void testGraphQLGetOrderRulesPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"orderRules",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetOrderRulesPageOrderRule_getGraphQLField();
 
 		// No namespace
 
@@ -1358,6 +1349,23 @@ public abstract class BaseOrderRuleResourceTestCase {
 			Arrays.asList(
 				OrderRuleSerDes.toDTOs(
 					orderRulesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetOrderRulesPageOrderRule_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"orderRules",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3120,4 +3128,4 @@ public abstract class BaseOrderRuleResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:2080332030
+// LIFERAY-REST-BUILDER-HASH:-653715214

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
@@ -1421,17 +1421,8 @@ public abstract class BaseOrderTypeResourceTestCase {
 
 	@Test
 	public void testGraphQLGetOrderTypesPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"orderTypes",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetOrderTypesPageOrderType_getGraphQLField();
 
 		// No namespace
 
@@ -1487,6 +1478,23 @@ public abstract class BaseOrderTypeResourceTestCase {
 			Arrays.asList(
 				OrderTypeSerDes.toDTOs(
 					orderTypesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetOrderTypesPageOrderType_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"orderTypes",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3002,4 +3010,4 @@ public abstract class BaseOrderTypeResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1709159002
+// LIFERAY-REST-BUILDER-HASH:565472736

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseTermResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseTermResourceTestCase.java
@@ -1236,17 +1236,8 @@ public abstract class BaseTermResourceTestCase {
 
 	@Test
 	public void testGraphQLGetTermsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"terms",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetTermsPageTerm_getGraphQLField();
 
 		// No namespace
 
@@ -1296,6 +1287,22 @@ public abstract class BaseTermResourceTestCase {
 			term2,
 			Arrays.asList(
 				TermSerDes.toDTOs(termsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField testGraphQLGetTermsPageTerm_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"terms",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2904,4 +2911,4 @@ public abstract class BaseTermResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-295237828
+// LIFERAY-REST-BUILDER-HASH:619673862

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-payment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/payment/resource/v1_0/test/BasePaymentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-payment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/payment/resource/v1_0/test/BasePaymentResourceTestCase.java
@@ -1283,17 +1283,8 @@ public abstract class BasePaymentResourceTestCase {
 
 	@Test
 	public void testGraphQLGetPaymentsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"payments",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetPaymentsPagePayment_getGraphQLField();
 
 		// No namespace
 
@@ -1343,6 +1334,22 @@ public abstract class BasePaymentResourceTestCase {
 			payment2,
 			Arrays.asList(
 				PaymentSerDes.toDTOs(paymentsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField testGraphQLGetPaymentsPagePayment_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"payments",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3878,4 +3885,4 @@ public abstract class BasePaymentResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-263483173
+// LIFERAY-REST-BUILDER-HASH:-1788511451

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountResourceTestCase.java
@@ -1060,16 +1060,8 @@ public abstract class BaseDiscountResourceTestCase {
 
 	@Test
 	public void testGraphQLGetDiscountsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"discounts",
-			new HashMap<String, Object>() {
-				{
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetDiscountsPageDiscount_getGraphQLField();
 
 		// No namespace
 
@@ -1119,6 +1111,21 @@ public abstract class BaseDiscountResourceTestCase {
 			discount2,
 			Arrays.asList(
 				DiscountSerDes.toDTOs(discountsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField testGraphQLGetDiscountsPageDiscount_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"discounts",
+			new HashMap<String, Object>() {
+				{
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2874,4 +2881,4 @@ public abstract class BaseDiscountResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1277206396
+// LIFERAY-REST-BUILDER-HASH:1864625358

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListResourceTestCase.java
@@ -1288,16 +1288,8 @@ public abstract class BasePriceListResourceTestCase {
 
 	@Test
 	public void testGraphQLGetPriceListsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"priceLists",
-			new HashMap<String, Object>() {
-				{
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetPriceListsPagePriceList_getGraphQLField();
 
 		// No namespace
 
@@ -1353,6 +1345,22 @@ public abstract class BasePriceListResourceTestCase {
 			Arrays.asList(
 				PriceListSerDes.toDTOs(
 					priceListsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetPriceListsPagePriceList_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"priceLists",
+			new HashMap<String, Object>() {
+				{
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2764,4 +2772,4 @@ public abstract class BasePriceListResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1070731472
+// LIFERAY-REST-BUILDER-HASH:330525512

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountResourceTestCase.java
@@ -1275,17 +1275,8 @@ public abstract class BaseDiscountResourceTestCase {
 
 	@Test
 	public void testGraphQLGetDiscountsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"discounts",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetDiscountsPageDiscount_getGraphQLField();
 
 		// No namespace
 
@@ -1335,6 +1326,22 @@ public abstract class BaseDiscountResourceTestCase {
 			discount2,
 			Arrays.asList(
 				DiscountSerDes.toDTOs(discountsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField testGraphQLGetDiscountsPageDiscount_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"discounts",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3504,4 +3511,4 @@ public abstract class BaseDiscountResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1980164423
+// LIFERAY-REST-BUILDER-HASH:2147478175

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListResourceTestCase.java
@@ -1297,17 +1297,8 @@ public abstract class BasePriceListResourceTestCase {
 
 	@Test
 	public void testGraphQLGetPriceListsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"priceLists",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetPriceListsPagePriceList_getGraphQLField();
 
 		// No namespace
 
@@ -1363,6 +1354,23 @@ public abstract class BasePriceListResourceTestCase {
 			Arrays.asList(
 				PriceListSerDes.toDTOs(
 					priceListsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetPriceListsPagePriceList_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"priceLists",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3468,4 +3476,4 @@ public abstract class BasePriceListResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1413758157
+// LIFERAY-REST-BUILDER-HASH:76491763

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentResourceTestCase.java
@@ -1275,17 +1275,8 @@ public abstract class BaseShipmentResourceTestCase {
 
 	@Test
 	public void testGraphQLGetShipmentsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"shipments",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetShipmentsPageShipment_getGraphQLField();
 
 		// No namespace
 
@@ -1335,6 +1326,22 @@ public abstract class BaseShipmentResourceTestCase {
 			shipment2,
 			Arrays.asList(
 				ShipmentSerDes.toDTOs(shipmentsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField testGraphQLGetShipmentsPageShipment_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"shipments",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3387,4 +3394,4 @@ public abstract class BaseShipmentResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-798302273
+// LIFERAY-REST-BUILDER-HASH:444217501

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseMeasurementUnitResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseMeasurementUnitResourceTestCase.java
@@ -1586,19 +1586,9 @@ public abstract class BaseMeasurementUnitResourceTestCase {
 		String measurementUnitType =
 			testGetMeasurementUnitsByType_getMeasurementUnitType();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"measurementUnitsByType",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"measurementUnitType",
-						"\"" + measurementUnitType + "\"");
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetMeasurementUnitsByTypeMeasurementUnit_getGraphQLField(
+				measurementUnitType);
 
 		// No namespace
 
@@ -1661,6 +1651,26 @@ public abstract class BaseMeasurementUnitResourceTestCase {
 			Arrays.asList(
 				MeasurementUnitSerDes.toDTOs(
 					measurementUnitsByTypeJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetMeasurementUnitsByTypeMeasurementUnit_getGraphQLField(
+				String measurementUnitType)
+		throws Exception {
+
+		return new GraphQLField(
+			"measurementUnitsByType",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"measurementUnitType",
+						"\"" + measurementUnitType + "\"");
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected MeasurementUnit
@@ -2048,16 +2058,8 @@ public abstract class BaseMeasurementUnitResourceTestCase {
 
 	@Test
 	public void testGraphQLGetMeasurementUnitsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"measurementUnits",
-			new HashMap<String, Object>() {
-				{
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetMeasurementUnitsPageMeasurementUnit_getGraphQLField();
 
 		// No namespace
 
@@ -2116,6 +2118,22 @@ public abstract class BaseMeasurementUnitResourceTestCase {
 			Arrays.asList(
 				MeasurementUnitSerDes.toDTOs(
 					measurementUnitsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetMeasurementUnitsPageMeasurementUnit_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"measurementUnits",
+			new HashMap<String, Object>() {
+				{
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3425,4 +3443,4 @@ public abstract class BaseMeasurementUnitResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1729057933
+// LIFERAY-REST-BUILDER-HASH:-878412798

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataLayoutResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataLayoutResourceTestCase.java
@@ -807,18 +807,9 @@ public abstract class BaseDataLayoutResourceTestCase {
 		Long dataDefinitionId =
 			testGetDataDefinitionDataLayoutsPage_getDataDefinitionId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"dataDefinitionDataLayouts",
-			new HashMap<String, Object>() {
-				{
-					put("dataDefinitionId", dataDefinitionId);
-					put("keywords", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetDataDefinitionDataLayoutsPageDataDefinitionDataLayout_getGraphQLField(
+				dataDefinitionId);
 
 		// No namespace
 
@@ -879,6 +870,25 @@ public abstract class BaseDataLayoutResourceTestCase {
 			Arrays.asList(
 				DataLayoutSerDes.toDTOs(
 					dataDefinitionDataLayoutsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetDataDefinitionDataLayoutsPageDataDefinitionDataLayout_getGraphQLField(
+				Long dataDefinitionId)
+		throws Exception {
+
+		return new GraphQLField(
+			"dataDefinitionDataLayouts",
+			new HashMap<String, Object>() {
+				{
+					put("dataDefinitionId", dataDefinitionId);
+					put("keywords", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2731,4 +2741,4 @@ public abstract class BaseDataLayoutResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-502886291
+// LIFERAY-REST-BUILDER-HASH:1947012903

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataListViewResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataListViewResourceTestCase.java
@@ -827,18 +827,9 @@ public abstract class BaseDataListViewResourceTestCase {
 		Long dataDefinitionId =
 			testGetDataDefinitionDataListViewsPage_getDataDefinitionId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"dataDefinitionDataListViews",
-			new HashMap<String, Object>() {
-				{
-					put("dataDefinitionId", dataDefinitionId);
-					put("keywords", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetDataDefinitionDataListViewsPageDataDefinitionDataListView_getGraphQLField(
+				dataDefinitionId);
 
 		// No namespace
 
@@ -899,6 +890,25 @@ public abstract class BaseDataListViewResourceTestCase {
 			Arrays.asList(
 				DataListViewSerDes.toDTOs(
 					dataDefinitionDataListViewsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetDataDefinitionDataListViewsPageDataDefinitionDataListView_getGraphQLField(
+				Long dataDefinitionId)
+		throws Exception {
+
+		return new GraphQLField(
+			"dataDefinitionDataListViews",
+			new HashMap<String, Object>() {
+				{
+					put("dataDefinitionId", dataDefinitionId);
+					put("keywords", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2416,4 +2426,4 @@ public abstract class BaseDataListViewResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1930501298
+// LIFERAY-REST-BUILDER-HASH:429709338

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordCollectionResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordCollectionResourceTestCase.java
@@ -782,18 +782,9 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 		Long dataDefinitionId =
 			testGetDataDefinitionDataRecordCollectionsPage_getDataDefinitionId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"dataDefinitionDataRecordCollections",
-			new HashMap<String, Object>() {
-				{
-					put("dataDefinitionId", dataDefinitionId);
-					put("keywords", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetDataDefinitionDataRecordCollectionsPageDataDefinitionDataRecordCollection_getGraphQLField(
+				dataDefinitionId);
 
 		// No namespace
 
@@ -862,6 +853,25 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 				DataRecordCollectionSerDes.toDTOs(
 					dataDefinitionDataRecordCollectionsJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetDataDefinitionDataRecordCollectionsPageDataDefinitionDataRecordCollection_getGraphQLField(
+				Long dataDefinitionId)
+		throws Exception {
+
+		return new GraphQLField(
+			"dataDefinitionDataRecordCollections",
+			new HashMap<String, Object>() {
+				{
+					put("dataDefinitionId", dataDefinitionId);
+					put("keywords", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2542,4 +2552,4 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-44246145
+// LIFERAY-REST-BUILDER-HASH:-1701851249

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordResourceTestCase.java
@@ -706,18 +706,9 @@ public abstract class BaseDataRecordResourceTestCase {
 		Long dataDefinitionId =
 			testGetDataDefinitionDataRecordsPage_getDataDefinitionId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"dataDefinitionDataRecords",
-			new HashMap<String, Object>() {
-				{
-					put("dataDefinitionId", dataDefinitionId);
-					put("keywords", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetDataDefinitionDataRecordsPageDataDefinitionDataRecord_getGraphQLField(
+				dataDefinitionId);
 
 		// No namespace
 
@@ -778,6 +769,25 @@ public abstract class BaseDataRecordResourceTestCase {
 			Arrays.asList(
 				DataRecordSerDes.toDTOs(
 					dataDefinitionDataRecordsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetDataDefinitionDataRecordsPageDataDefinitionDataRecord_getGraphQLField(
+				Long dataDefinitionId)
+		throws Exception {
+
+		return new GraphQLField(
+			"dataDefinitionDataRecords",
+			new HashMap<String, Object>() {
+				{
+					put("dataDefinitionId", dataDefinitionId);
+					put("keywords", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -1440,18 +1450,9 @@ public abstract class BaseDataRecordResourceTestCase {
 		Long dataRecordCollectionId =
 			testGetDataRecordCollectionDataRecordsPage_getDataRecordCollectionId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"dataRecordCollectionDataRecords",
-			new HashMap<String, Object>() {
-				{
-					put("dataRecordCollectionId", dataRecordCollectionId);
-					put("keywords", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetDataRecordCollectionDataRecordsPageDataRecordCollectionDataRecord_getGraphQLField(
+				dataRecordCollectionId);
 
 		// No namespace
 
@@ -1518,6 +1519,25 @@ public abstract class BaseDataRecordResourceTestCase {
 				DataRecordSerDes.toDTOs(
 					dataRecordCollectionDataRecordsJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetDataRecordCollectionDataRecordsPageDataRecordCollectionDataRecord_getGraphQLField(
+				Long dataRecordCollectionId)
+		throws Exception {
+
+		return new GraphQLField(
+			"dataRecordCollectionDataRecords",
+			new HashMap<String, Object>() {
+				{
+					put("dataRecordCollectionId", dataRecordCollectionId);
+					put("keywords", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2626,4 +2646,4 @@ public abstract class BaseDataRecordResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:952592255
+// LIFERAY-REST-BUILDER-HASH:341876255

--- a/modules/apps/digital-signature/digital-signature-rest-test/src/testIntegration/java/com/liferay/digital/signature/rest/resource/v1_0/test/BaseDSEnvelopeResourceTestCase.java
+++ b/modules/apps/digital-signature/digital-signature-rest-test/src/testIntegration/java/com/liferay/digital/signature/rest/resource/v1_0/test/BaseDSEnvelopeResourceTestCase.java
@@ -494,27 +494,9 @@ public abstract class BaseDSEnvelopeResourceTestCase {
 	public void testGraphQLGetSiteDSEnvelopesPage() throws Exception {
 		Long siteId = testGetSiteDSEnvelopesPage_getSiteId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"dSEnvelopes",
-			new HashMap<String, Object>() {
-				{
-					put("siteKey", "\"" + siteId + "\"");
-					put(
-						"fromDate",
-						getGraphQLValue(RandomTestUtil.randomString()));
-					put("keywords", null);
-					put(
-						"order",
-						getGraphQLValue(RandomTestUtil.randomString()));
-					put(
-						"status",
-						getGraphQLValue(RandomTestUtil.randomString()));
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteDSEnvelopesPageSiteDSEnvelope_getGraphQLField(
+				siteId);
 
 		// No namespace
 
@@ -569,6 +551,34 @@ public abstract class BaseDSEnvelopeResourceTestCase {
 			Arrays.asList(
 				DSEnvelopeSerDes.toDTOs(
 					dSEnvelopesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteDSEnvelopesPageSiteDSEnvelope_getGraphQLField(
+				Long siteId)
+		throws Exception {
+
+		return new GraphQLField(
+			"dSEnvelopes",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+					put(
+						"fromDate",
+						getGraphQLValue(RandomTestUtil.randomString()));
+					put("keywords", null);
+					put(
+						"order",
+						getGraphQLValue(RandomTestUtil.randomString()));
+					put(
+						"status",
+						getGraphQLValue(RandomTestUtil.randomString()));
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -1854,4 +1864,4 @@ public abstract class BaseDSEnvelopeResourceTestCase {
 		_dsEnvelopeResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1814703680
+// LIFERAY-REST-BUILDER-HASH:179629646

--- a/modules/apps/dispatch/dispatch-rest-test/src/testIntegration/java/com/liferay/dispatch/rest/resource/v1_0/test/BaseDispatchTriggerResourceTestCase.java
+++ b/modules/apps/dispatch/dispatch-rest-test/src/testIntegration/java/com/liferay/dispatch/rest/resource/v1_0/test/BaseDispatchTriggerResourceTestCase.java
@@ -236,14 +236,8 @@ public abstract class BaseDispatchTriggerResourceTestCase {
 
 	@Test
 	public void testGraphQLGetDispatchTriggersPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"dispatchTriggers",
-			new HashMap<String, Object>() {
-				{
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetDispatchTriggersPageDispatchTrigger_getGraphQLField();
 
 		// No namespace
 
@@ -299,6 +293,20 @@ public abstract class BaseDispatchTriggerResourceTestCase {
 			Arrays.asList(
 				DispatchTriggerSerDes.toDTOs(
 					dispatchTriggersJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetDispatchTriggersPageDispatchTrigger_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"dispatchTriggers",
+			new HashMap<String, Object>() {
+				{
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -1712,4 +1720,4 @@ public abstract class BaseDispatchTriggerResourceTestCase {
 		_dispatchTriggerResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1067200783
+// LIFERAY-REST-BUILDER-HASH:-1624823235

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-test/src/testIntegration/java/com/liferay/headless/admin/address/resource/v1_0/test/BaseCountryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-test/src/testIntegration/java/com/liferay/headless/admin/address/resource/v1_0/test/BaseCountryResourceTestCase.java
@@ -828,17 +828,8 @@ public abstract class BaseCountryResourceTestCase {
 
 	@Test
 	public void testGraphQLGetCountriesPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"countries",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetCountriesPageCountry_getGraphQLField();
 
 		// No namespace
 
@@ -887,6 +878,22 @@ public abstract class BaseCountryResourceTestCase {
 			country2,
 			Arrays.asList(
 				CountrySerDes.toDTOs(countriesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField testGraphQLGetCountriesPageCountry_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"countries",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3390,4 +3397,4 @@ public abstract class BaseCountryResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:884740839
+// LIFERAY-REST-BUILDER-HASH:1988510671

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-test/src/testIntegration/java/com/liferay/headless/admin/address/resource/v1_0/test/BaseRegionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-test/src/testIntegration/java/com/liferay/headless/admin/address/resource/v1_0/test/BaseRegionResourceTestCase.java
@@ -949,18 +949,9 @@ public abstract class BaseRegionResourceTestCase {
 	public void testGraphQLGetCountryRegionsPage() throws Exception {
 		Long countryId = testGetCountryRegionsPage_getCountryId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"countryRegions",
-			new HashMap<String, Object>() {
-				{
-					put("countryId", countryId);
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetCountryRegionsPageCountryRegion_getGraphQLField(
+				countryId);
 
 		// No namespace
 
@@ -1015,6 +1006,25 @@ public abstract class BaseRegionResourceTestCase {
 			Arrays.asList(
 				RegionSerDes.toDTOs(
 					countryRegionsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetCountryRegionsPageCountryRegion_getGraphQLField(
+				Long countryId)
+		throws Exception {
+
+		return new GraphQLField(
+			"countryRegions",
+			new HashMap<String, Object>() {
+				{
+					put("countryId", countryId);
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3163,4 +3173,4 @@ public abstract class BaseRegionResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1021205880
+// LIFERAY-REST-BUILDER-HASH:-497217834

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeDefinitionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeDefinitionResourceTestCase.java
@@ -1263,17 +1263,8 @@ public abstract class BaseListTypeDefinitionResourceTestCase {
 
 	@Test
 	public void testGraphQLGetListTypeDefinitionsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"listTypeDefinitions",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetListTypeDefinitionsPageListTypeDefinition_getGraphQLField();
 
 		// No namespace
 
@@ -1333,6 +1324,23 @@ public abstract class BaseListTypeDefinitionResourceTestCase {
 			Arrays.asList(
 				ListTypeDefinitionSerDes.toDTOs(
 					listTypeDefinitionsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetListTypeDefinitionsPageListTypeDefinition_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"listTypeDefinitions",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2817,4 +2825,4 @@ public abstract class BaseListTypeDefinitionResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-291678679
+// LIFERAY-REST-BUILDER-HASH:2092135309

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeEntryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeEntryResourceTestCase.java
@@ -863,20 +863,9 @@ public abstract class BaseListTypeEntryResourceTestCase {
 		String externalReferenceCode =
 			testGetListTypeDefinitionByExternalReferenceCodeListTypeEntriesPage_getExternalReferenceCode();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"listTypeDefinitionByExternalReferenceCodeListTypeEntries",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"externalReferenceCode",
-						"\"" + externalReferenceCode + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetListTypeDefinitionByExternalReferenceCodeListTypeEntriesPageListTypeDefinitionListTypeEntry_getGraphQLField(
+				externalReferenceCode);
 
 		// No namespace
 
@@ -948,6 +937,27 @@ public abstract class BaseListTypeEntryResourceTestCase {
 				ListTypeEntrySerDes.toDTOs(
 					listTypeDefinitionByExternalReferenceCodeListTypeEntriesJSONObject.
 						getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetListTypeDefinitionByExternalReferenceCodeListTypeEntriesPageListTypeDefinitionListTypeEntry_getGraphQLField(
+				String externalReferenceCode)
+		throws Exception {
+
+		return new GraphQLField(
+			"listTypeDefinitionByExternalReferenceCodeListTypeEntries",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"externalReferenceCode",
+						"\"" + externalReferenceCode + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected ListTypeEntry
@@ -1435,18 +1445,9 @@ public abstract class BaseListTypeEntryResourceTestCase {
 		Long listTypeDefinitionId =
 			testGetListTypeDefinitionListTypeEntriesPage_getListTypeDefinitionId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"listTypeDefinitionListTypeEntries",
-			new HashMap<String, Object>() {
-				{
-					put("listTypeDefinitionId", listTypeDefinitionId);
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetListTypeDefinitionListTypeEntriesPageListTypeDefinitionListTypeEntry_getGraphQLField(
+				listTypeDefinitionId);
 
 		// No namespace
 
@@ -1514,6 +1515,25 @@ public abstract class BaseListTypeEntryResourceTestCase {
 				ListTypeEntrySerDes.toDTOs(
 					listTypeDefinitionListTypeEntriesJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetListTypeDefinitionListTypeEntriesPageListTypeDefinitionListTypeEntry_getGraphQLField(
+				Long listTypeDefinitionId)
+		throws Exception {
+
+		return new GraphQLField(
+			"listTypeDefinitionListTypeEntries",
+			new HashMap<String, Object>() {
+				{
+					put("listTypeDefinitionId", listTypeDefinitionId);
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3274,4 +3294,4 @@ public abstract class BaseListTypeEntryResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-881414567
+// LIFERAY-REST-BUILDER-HASH:-1129782780

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -1353,18 +1353,9 @@ public abstract class BaseKeywordResourceTestCase {
 		Long assetLibraryId =
 			testGetAssetLibraryKeywordsPage_getAssetLibraryId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"assetLibraryKeywords",
-			new HashMap<String, Object>() {
-				{
-					put("assetLibraryId", "\"" + assetLibraryId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAssetLibraryKeywordsPageAssetLibraryKeyword_getGraphQLField(
+				assetLibraryId);
 
 		// No namespace
 
@@ -1422,6 +1413,25 @@ public abstract class BaseKeywordResourceTestCase {
 			Arrays.asList(
 				KeywordSerDes.toDTOs(
 					assetLibraryKeywordsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetAssetLibraryKeywordsPageAssetLibraryKeyword_getGraphQLField(
+				Long assetLibraryId)
+		throws Exception {
+
+		return new GraphQLField(
+			"assetLibraryKeywords",
+			new HashMap<String, Object>() {
+				{
+					put("assetLibraryId", "\"" + assetLibraryId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -1842,17 +1852,8 @@ public abstract class BaseKeywordResourceTestCase {
 
 	@Test
 	public void testGraphQLGetKeywordsRankedPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"keywordsRanked",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetKeywordsRankedPageKeyword_getGraphQLField();
 
 		// No namespace
 
@@ -1907,6 +1908,23 @@ public abstract class BaseKeywordResourceTestCase {
 			Arrays.asList(
 				KeywordSerDes.toDTOs(
 					keywordsRankedJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetKeywordsRankedPageKeyword_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"keywordsRanked",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected Keyword testGraphQLGetKeywordsRankedPageKeyword_addKeyword(
@@ -2498,18 +2516,8 @@ public abstract class BaseKeywordResourceTestCase {
 	public void testGraphQLGetSiteKeywordsPage() throws Exception {
 		Long siteId = testGetSiteKeywordsPage_getSiteId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"keywords",
-			new HashMap<String, Object>() {
-				{
-					put("siteKey", "\"" + siteId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteKeywordsPageSiteKeyword_getGraphQLField(siteId);
 
 		// No namespace
 
@@ -2560,6 +2568,25 @@ public abstract class BaseKeywordResourceTestCase {
 			keyword2,
 			Arrays.asList(
 				KeywordSerDes.toDTOs(keywordsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteKeywordsPageSiteKeyword_getGraphQLField(
+				Long siteId)
+		throws Exception {
+
+		return new GraphQLField(
+			"keywords",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -4433,4 +4460,4 @@ public abstract class BaseKeywordResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1829607848
+// LIFERAY-REST-BUILDER-HASH:1395076406

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -1402,18 +1402,9 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		Long assetLibraryId =
 			testGetAssetLibraryTaxonomyCategoriesPage_getAssetLibraryId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"assetLibraryTaxonomyCategories",
-			new HashMap<String, Object>() {
-				{
-					put("assetLibraryId", "\"" + assetLibraryId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAssetLibraryTaxonomyCategoriesPageAssetLibraryTaxonomyCategory_getGraphQLField(
+				assetLibraryId);
 
 		// No namespace
 
@@ -1481,6 +1472,25 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 				TaxonomyCategorySerDes.toDTOs(
 					assetLibraryTaxonomyCategoriesJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetAssetLibraryTaxonomyCategoriesPageAssetLibraryTaxonomyCategory_getGraphQLField(
+				Long assetLibraryId)
+		throws Exception {
+
+		return new GraphQLField(
+			"assetLibraryTaxonomyCategories",
+			new HashMap<String, Object>() {
+				{
+					put("assetLibraryId", "\"" + assetLibraryId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2138,18 +2148,9 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 	public void testGraphQLGetSiteTaxonomyCategoriesPage() throws Exception {
 		Long siteId = testGetSiteTaxonomyCategoriesPage_getSiteId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"taxonomyCategories",
-			new HashMap<String, Object>() {
-				{
-					put("siteKey", "\"" + siteId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteTaxonomyCategoriesPageSiteTaxonomyCategory_getGraphQLField(
+				siteId);
 
 		// No namespace
 
@@ -2206,6 +2207,25 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 			Arrays.asList(
 				TaxonomyCategorySerDes.toDTOs(
 					taxonomyCategoriesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteTaxonomyCategoriesPageSiteTaxonomyCategory_getGraphQLField(
+				Long siteId)
+		throws Exception {
+
+		return new GraphQLField(
+			"taxonomyCategories",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2526,16 +2546,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 
 	@Test
 	public void testGraphQLGetTaxonomyCategoriesRankedPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"taxonomyCategoriesRanked",
-			new HashMap<String, Object>() {
-				{
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetTaxonomyCategoriesRankedPageTaxonomyCategory_getGraphQLField();
 
 		// No namespace
 
@@ -2596,6 +2608,22 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 			Arrays.asList(
 				TaxonomyCategorySerDes.toDTOs(
 					taxonomyCategoriesRankedJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetTaxonomyCategoriesRankedPageTaxonomyCategory_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"taxonomyCategoriesRanked",
+			new HashMap<String, Object>() {
+				{
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected TaxonomyCategory
@@ -3281,20 +3309,9 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		String parentTaxonomyCategoryId =
 			testGetTaxonomyCategoryTaxonomyCategoriesPage_getParentTaxonomyCategoryId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"taxonomyCategoryTaxonomyCategories",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"parentTaxonomyCategoryId",
-						"\"" + parentTaxonomyCategoryId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetTaxonomyCategoryTaxonomyCategoriesPageTaxonomyCategory_getGraphQLField(
+				parentTaxonomyCategoryId);
 
 		// No namespace
 
@@ -3362,6 +3379,27 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 				TaxonomyCategorySerDes.toDTOs(
 					taxonomyCategoryTaxonomyCategoriesJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetTaxonomyCategoryTaxonomyCategoriesPageTaxonomyCategory_getGraphQLField(
+				String parentTaxonomyCategoryId)
+		throws Exception {
+
+		return new GraphQLField(
+			"taxonomyCategoryTaxonomyCategories",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"parentTaxonomyCategoryId",
+						"\"" + parentTaxonomyCategoryId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected TaxonomyCategory
@@ -3888,18 +3926,9 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		Long taxonomyVocabularyId =
 			testGetTaxonomyVocabularyTaxonomyCategoriesPage_getTaxonomyVocabularyId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"taxonomyVocabularyTaxonomyCategories",
-			new HashMap<String, Object>() {
-				{
-					put("taxonomyVocabularyId", taxonomyVocabularyId);
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetTaxonomyVocabularyTaxonomyCategoriesPageTaxonomyVocabularyTaxonomyCategory_getGraphQLField(
+				taxonomyVocabularyId);
 
 		// No namespace
 
@@ -3970,6 +3999,25 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 				TaxonomyCategorySerDes.toDTOs(
 					taxonomyVocabularyTaxonomyCategoriesJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetTaxonomyVocabularyTaxonomyCategoriesPageTaxonomyVocabularyTaxonomyCategory_getGraphQLField(
+				Long taxonomyVocabularyId)
+		throws Exception {
+
+		return new GraphQLField(
+			"taxonomyVocabularyTaxonomyCategories",
+			new HashMap<String, Object>() {
+				{
+					put("taxonomyVocabularyId", taxonomyVocabularyId);
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -6933,4 +6981,4 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 			TaxonomyCategoryResource _taxonomyCategoryResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1689225875
+// LIFERAY-REST-BUILDER-HASH:-1919811996

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -1281,18 +1281,9 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		Long assetLibraryId =
 			testGetAssetLibraryTaxonomyVocabulariesPage_getAssetLibraryId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"assetLibraryTaxonomyVocabularies",
-			new HashMap<String, Object>() {
-				{
-					put("assetLibraryId", "\"" + assetLibraryId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAssetLibraryTaxonomyVocabulariesPageAssetLibraryTaxonomyVocabulary_getGraphQLField(
+				assetLibraryId);
 
 		// No namespace
 
@@ -1360,6 +1351,25 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 				TaxonomyVocabularySerDes.toDTOs(
 					assetLibraryTaxonomyVocabulariesJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetAssetLibraryTaxonomyVocabulariesPageAssetLibraryTaxonomyVocabulary_getGraphQLField(
+				Long assetLibraryId)
+		throws Exception {
+
+		return new GraphQLField(
+			"assetLibraryTaxonomyVocabularies",
+			new HashMap<String, Object>() {
+				{
+					put("assetLibraryId", "\"" + assetLibraryId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2099,18 +2109,9 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 	public void testGraphQLGetSiteTaxonomyVocabulariesPage() throws Exception {
 		Long siteId = testGetSiteTaxonomyVocabulariesPage_getSiteId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"taxonomyVocabularies",
-			new HashMap<String, Object>() {
-				{
-					put("siteKey", "\"" + siteId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteTaxonomyVocabulariesPageSiteTaxonomyVocabulary_getGraphQLField(
+				siteId);
 
 		// No namespace
 
@@ -2170,6 +2171,25 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			Arrays.asList(
 				TaxonomyVocabularySerDes.toDTOs(
 					taxonomyVocabulariesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteTaxonomyVocabulariesPageSiteTaxonomyVocabulary_getGraphQLField(
+				Long siteId)
+		throws Exception {
+
+		return new GraphQLField(
+			"taxonomyVocabularies",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -5294,4 +5314,4 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1170646971
+// LIFERAY-REST-BUILDER-HASH:918371193

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountGroupResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountGroupResourceTestCase.java
@@ -1834,17 +1834,8 @@ public abstract class BaseAccountGroupResourceTestCase {
 
 	@Test
 	public void testGraphQLGetAccountGroupsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"accountGroups",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAccountGroupsPageAccountGroup_getGraphQLField();
 
 		// No namespace
 
@@ -1899,6 +1890,23 @@ public abstract class BaseAccountGroupResourceTestCase {
 			Arrays.asList(
 				AccountGroupSerDes.toDTOs(
 					accountGroupsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetAccountGroupsPageAccountGroup_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"accountGroups",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3389,4 +3397,4 @@ public abstract class BaseAccountGroupResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1271294540
+// LIFERAY-REST-BUILDER-HASH:-1334730434

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -2502,17 +2502,8 @@ public abstract class BaseAccountResourceTestCase {
 
 	@Test
 	public void testGraphQLGetAccountsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"accounts",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAccountsPageAccount_getGraphQLField();
 
 		// No namespace
 
@@ -2561,6 +2552,22 @@ public abstract class BaseAccountResourceTestCase {
 			account2,
 			Arrays.asList(
 				AccountSerDes.toDTOs(accountsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField testGraphQLGetAccountsPageAccount_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"accounts",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3877,20 +3884,9 @@ public abstract class BaseAccountResourceTestCase {
 		String organizationExternalReferenceCode =
 			testGetOrganizationByExternalReferenceCodeOrganizationExternalReferenceCodeAccountsByExternalReferenceCodePage_getOrganizationExternalReferenceCode();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"organizationByExternalReferenceCodeOrganizationExternalReferenceCodeAccountsByExternalReferenceCode",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"organizationExternalReferenceCode",
-						"\"" + organizationExternalReferenceCode + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetOrganizationByExternalReferenceCodeOrganizationExternalReferenceCodeAccountsByExternalReferenceCodePageAccount_getGraphQLField(
+				organizationExternalReferenceCode);
 
 		// No namespace
 
@@ -3961,6 +3957,27 @@ public abstract class BaseAccountResourceTestCase {
 				AccountSerDes.toDTOs(
 					organizationByExternalReferenceCodeOrganizationExternalReferenceCodeAccountsByExternalReferenceCodeJSONObject.
 						getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetOrganizationByExternalReferenceCodeOrganizationExternalReferenceCodeAccountsByExternalReferenceCodePageAccount_getGraphQLField(
+				String organizationExternalReferenceCode)
+		throws Exception {
+
+		return new GraphQLField(
+			"organizationByExternalReferenceCodeOrganizationExternalReferenceCodeAccountsByExternalReferenceCode",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"organizationExternalReferenceCode",
+						"\"" + organizationExternalReferenceCode + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected Account
@@ -6527,4 +6544,4 @@ public abstract class BaseAccountResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:2060527496
+// LIFERAY-REST-BUILDER-HASH:-618723767

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
@@ -1302,20 +1302,9 @@ public abstract class BaseAccountRoleResourceTestCase {
 		String externalReferenceCode =
 			testGetAccountAccountRolesByExternalReferenceCodePage_getExternalReferenceCode();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"accountAccountRolesByExternalReferenceCode",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"externalReferenceCode",
-						"\"" + externalReferenceCode + "\"");
-					put("keywords", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAccountAccountRolesByExternalReferenceCodePageAccountAccountRole_getGraphQLField(
+				externalReferenceCode);
 
 		// No namespace
 
@@ -1385,6 +1374,27 @@ public abstract class BaseAccountRoleResourceTestCase {
 				AccountRoleSerDes.toDTOs(
 					accountAccountRolesByExternalReferenceCodeJSONObject.
 						getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetAccountAccountRolesByExternalReferenceCodePageAccountAccountRole_getGraphQLField(
+				String externalReferenceCode)
+		throws Exception {
+
+		return new GraphQLField(
+			"accountAccountRolesByExternalReferenceCode",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"externalReferenceCode",
+						"\"" + externalReferenceCode + "\"");
+					put("keywords", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected AccountRole
@@ -1829,18 +1839,9 @@ public abstract class BaseAccountRoleResourceTestCase {
 	public void testGraphQLGetAccountAccountRolesPage() throws Exception {
 		Long accountId = testGetAccountAccountRolesPage_getAccountId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"accountAccountRoles",
-			new HashMap<String, Object>() {
-				{
-					put("accountId", accountId);
-					put("keywords", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAccountAccountRolesPageAccountAccountRole_getGraphQLField(
+				accountId);
 
 		// No namespace
 
@@ -1898,6 +1899,25 @@ public abstract class BaseAccountRoleResourceTestCase {
 			Arrays.asList(
 				AccountRoleSerDes.toDTOs(
 					accountAccountRolesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetAccountAccountRolesPageAccountAccountRole_getGraphQLField(
+				Long accountId)
+		throws Exception {
+
+		return new GraphQLField(
+			"accountAccountRoles",
+			new HashMap<String, Object>() {
+				{
+					put("accountId", accountId);
+					put("keywords", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3544,4 +3564,4 @@ public abstract class BaseAccountRoleResourceTestCase {
 		_accountRoleResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:653556514
+// LIFERAY-REST-BUILDER-HASH:-1860062267

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
@@ -1865,20 +1865,9 @@ public abstract class BaseOrganizationResourceTestCase {
 		String externalReferenceCode =
 			testGetAccountByExternalReferenceCodeOrganizationsPage_getExternalReferenceCode();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"accountByExternalReferenceCodeOrganizations",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"externalReferenceCode",
-						"\"" + externalReferenceCode + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAccountByExternalReferenceCodeOrganizationsPageAccountOrganization_getGraphQLField(
+				externalReferenceCode);
 
 		// No namespace
 
@@ -1948,6 +1937,27 @@ public abstract class BaseOrganizationResourceTestCase {
 				OrganizationSerDes.toDTOs(
 					accountByExternalReferenceCodeOrganizationsJSONObject.
 						getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetAccountByExternalReferenceCodeOrganizationsPageAccountOrganization_getGraphQLField(
+				String externalReferenceCode)
+		throws Exception {
+
+		return new GraphQLField(
+			"accountByExternalReferenceCodeOrganizations",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"externalReferenceCode",
+						"\"" + externalReferenceCode + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected Organization
@@ -2537,18 +2547,9 @@ public abstract class BaseOrganizationResourceTestCase {
 	public void testGraphQLGetAccountOrganizationsPage() throws Exception {
 		Long accountId = testGetAccountOrganizationsPage_getAccountId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"accountOrganizations",
-			new HashMap<String, Object>() {
-				{
-					put("accountId", accountId);
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAccountOrganizationsPageAccountOrganization_getGraphQLField(
+				accountId);
 
 		// No namespace
 
@@ -2608,6 +2609,25 @@ public abstract class BaseOrganizationResourceTestCase {
 			Arrays.asList(
 				OrganizationSerDes.toDTOs(
 					accountOrganizationsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetAccountOrganizationsPageAccountOrganization_getGraphQLField(
+				Long accountId)
+		throws Exception {
+
+		return new GraphQLField(
+			"accountOrganizations",
+			new HashMap<String, Object>() {
+				{
+					put("accountId", accountId);
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected Organization
@@ -3347,20 +3367,9 @@ public abstract class BaseOrganizationResourceTestCase {
 		String externalReferenceCode =
 			testGetOrganizationByExternalReferenceCodeChildOrganizationsPage_getExternalReferenceCode();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"organizationByExternalReferenceCodeChildOrganizations",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"externalReferenceCode",
-						"\"" + externalReferenceCode + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetOrganizationByExternalReferenceCodeChildOrganizationsPageOrganization_getGraphQLField(
+				externalReferenceCode);
 
 		// No namespace
 
@@ -3431,6 +3440,27 @@ public abstract class BaseOrganizationResourceTestCase {
 				OrganizationSerDes.toDTOs(
 					organizationByExternalReferenceCodeChildOrganizationsJSONObject.
 						getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetOrganizationByExternalReferenceCodeChildOrganizationsPageOrganization_getGraphQLField(
+				String externalReferenceCode)
+		throws Exception {
+
+		return new GraphQLField(
+			"organizationByExternalReferenceCodeChildOrganizations",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"externalReferenceCode",
+						"\"" + externalReferenceCode + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected Organization
@@ -3894,18 +3924,9 @@ public abstract class BaseOrganizationResourceTestCase {
 		String organizationId =
 			testGetOrganizationChildOrganizationsPage_getOrganizationId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"organizationChildOrganizations",
-			new HashMap<String, Object>() {
-				{
-					put("organizationId", "\"" + organizationId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetOrganizationChildOrganizationsPageOrganization_getGraphQLField(
+				organizationId);
 
 		// No namespace
 
@@ -3972,6 +3993,25 @@ public abstract class BaseOrganizationResourceTestCase {
 				OrganizationSerDes.toDTOs(
 					organizationChildOrganizationsJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetOrganizationChildOrganizationsPageOrganization_getGraphQLField(
+				String organizationId)
+		throws Exception {
+
+		return new GraphQLField(
+			"organizationChildOrganizations",
+			new HashMap<String, Object>() {
+				{
+					put("organizationId", "\"" + organizationId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected Organization
@@ -4431,20 +4471,9 @@ public abstract class BaseOrganizationResourceTestCase {
 		String parentOrganizationId =
 			testGetOrganizationOrganizationsPage_getParentOrganizationId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"organizationOrganizations",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"parentOrganizationId",
-						"\"" + parentOrganizationId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetOrganizationOrganizationsPageOrganization_getGraphQLField(
+				parentOrganizationId);
 
 		// No namespace
 
@@ -4505,6 +4534,27 @@ public abstract class BaseOrganizationResourceTestCase {
 			Arrays.asList(
 				OrganizationSerDes.toDTOs(
 					organizationOrganizationsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetOrganizationOrganizationsPageOrganization_getGraphQLField(
+				String parentOrganizationId)
+		throws Exception {
+
+		return new GraphQLField(
+			"organizationOrganizations",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"parentOrganizationId",
+						"\"" + parentOrganizationId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected Organization
@@ -4875,17 +4925,8 @@ public abstract class BaseOrganizationResourceTestCase {
 
 	@Test
 	public void testGraphQLGetOrganizationsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"organizations",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetOrganizationsPageOrganization_getGraphQLField();
 
 		// No namespace
 
@@ -4940,6 +4981,23 @@ public abstract class BaseOrganizationResourceTestCase {
 			Arrays.asList(
 				OrganizationSerDes.toDTOs(
 					organizationsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetOrganizationsPageOrganization_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"organizations",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -8049,4 +8107,4 @@ public abstract class BaseOrganizationResourceTestCase {
 		_organizationResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:165327054
+// LIFERAY-REST-BUILDER-HASH:1392319792

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePostalAddressResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePostalAddressResourceTestCase.java
@@ -670,17 +670,9 @@ public abstract class BasePostalAddressResourceTestCase {
 		String externalReferenceCode =
 			testGetAccountByExternalReferenceCodePostalAddressesPage_getExternalReferenceCode();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"accountByExternalReferenceCodePostalAddresses",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"externalReferenceCode",
-						"\"" + externalReferenceCode + "\"");
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAccountByExternalReferenceCodePostalAddressesPageAccountPostalAddress_getGraphQLField(
+				externalReferenceCode);
 
 		// No namespace
 
@@ -750,6 +742,24 @@ public abstract class BasePostalAddressResourceTestCase {
 				PostalAddressSerDes.toDTOs(
 					accountByExternalReferenceCodePostalAddressesJSONObject.
 						getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetAccountByExternalReferenceCodePostalAddressesPageAccountPostalAddress_getGraphQLField(
+				String externalReferenceCode)
+		throws Exception {
+
+		return new GraphQLField(
+			"accountByExternalReferenceCodePostalAddresses",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"externalReferenceCode",
+						"\"" + externalReferenceCode + "\"");
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected PostalAddress
@@ -857,15 +867,9 @@ public abstract class BasePostalAddressResourceTestCase {
 	public void testGraphQLGetAccountPostalAddressesPage() throws Exception {
 		Long accountId = testGetAccountPostalAddressesPage_getAccountId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"accountPostalAddresses",
-			new HashMap<String, Object>() {
-				{
-					put("accountId", accountId);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAccountPostalAddressesPageAccountPostalAddress_getGraphQLField(
+				accountId);
 
 		// No namespace
 
@@ -926,6 +930,22 @@ public abstract class BasePostalAddressResourceTestCase {
 			Arrays.asList(
 				PostalAddressSerDes.toDTOs(
 					accountPostalAddressesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetAccountPostalAddressesPageAccountPostalAddress_getGraphQLField(
+				Long accountId)
+		throws Exception {
+
+		return new GraphQLField(
+			"accountPostalAddresses",
+			new HashMap<String, Object>() {
+				{
+					put("accountId", accountId);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3841,4 +3861,4 @@ public abstract class BasePostalAddressResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1195882055
+// LIFERAY-REST-BUILDER-HASH:1333195172

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseRoleResourceTestCase.java
@@ -1806,17 +1806,8 @@ public abstract class BaseRoleResourceTestCase {
 
 	@Test
 	public void testGraphQLGetRolesPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"roles",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetRolesPageRole_getGraphQLField();
 
 		// No namespace
 
@@ -1865,6 +1856,22 @@ public abstract class BaseRoleResourceTestCase {
 			role2,
 			Arrays.asList(
 				RoleSerDes.toDTOs(rolesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField testGraphQLGetRolesPageRole_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"roles",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3669,4 +3676,4 @@ public abstract class BaseRoleResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1390689137
+// LIFERAY-REST-BUILDER-HASH:1486184605

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -2060,20 +2060,9 @@ public abstract class BaseUserAccountResourceTestCase {
 		String externalReferenceCode =
 			testGetAccountUserAccountsByExternalReferenceCodePage_getExternalReferenceCode();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"accountUserAccountsByExternalReferenceCode",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"externalReferenceCode",
-						"\"" + externalReferenceCode + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAccountUserAccountsByExternalReferenceCodePageAccountUserAccount_getGraphQLField(
+				externalReferenceCode);
 
 		// No namespace
 
@@ -2143,6 +2132,27 @@ public abstract class BaseUserAccountResourceTestCase {
 				UserAccountSerDes.toDTOs(
 					accountUserAccountsByExternalReferenceCodeJSONObject.
 						getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetAccountUserAccountsByExternalReferenceCodePageAccountUserAccount_getGraphQLField(
+				String externalReferenceCode)
+		throws Exception {
+
+		return new GraphQLField(
+			"accountUserAccountsByExternalReferenceCode",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"externalReferenceCode",
+						"\"" + externalReferenceCode + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected UserAccount
@@ -2591,18 +2601,9 @@ public abstract class BaseUserAccountResourceTestCase {
 	public void testGraphQLGetAccountUserAccountsPage() throws Exception {
 		Long accountId = testGetAccountUserAccountsPage_getAccountId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"accountUserAccounts",
-			new HashMap<String, Object>() {
-				{
-					put("accountId", accountId);
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAccountUserAccountsPageAccountUserAccount_getGraphQLField(
+				accountId);
 
 		// No namespace
 
@@ -2660,6 +2661,25 @@ public abstract class BaseUserAccountResourceTestCase {
 			Arrays.asList(
 				UserAccountSerDes.toDTOs(
 					accountUserAccountsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetAccountUserAccountsPageAccountUserAccount_getGraphQLField(
+				Long accountId)
+		throws Exception {
+
+		return new GraphQLField(
+			"accountUserAccounts",
+			new HashMap<String, Object>() {
+				{
+					put("accountId", accountId);
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -5001,18 +5021,9 @@ public abstract class BaseUserAccountResourceTestCase {
 	public void testGraphQLGetUserAccountsByStatusPage() throws Exception {
 		String status = testGetUserAccountsByStatusPage_getStatus();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"userAccountsByStatus",
-			new HashMap<String, Object>() {
-				{
-					put("status", "\"" + status + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetUserAccountsByStatusPageUserAccount_getGraphQLField(
+				status);
 
 		// No namespace
 
@@ -5072,6 +5083,25 @@ public abstract class BaseUserAccountResourceTestCase {
 			Arrays.asList(
 				UserAccountSerDes.toDTOs(
 					userAccountsByStatusJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetUserAccountsByStatusPageUserAccount_getGraphQLField(
+				String status)
+		throws Exception {
+
+		return new GraphQLField(
+			"userAccountsByStatus",
+			new HashMap<String, Object>() {
+				{
+					put("status", "\"" + status + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected UserAccount
@@ -5425,17 +5455,8 @@ public abstract class BaseUserAccountResourceTestCase {
 
 	@Test
 	public void testGraphQLGetUserAccountsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"userAccounts",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetUserAccountsPageUserAccount_getGraphQLField();
 
 		// No namespace
 
@@ -5490,6 +5511,23 @@ public abstract class BaseUserAccountResourceTestCase {
 			Arrays.asList(
 				UserAccountSerDes.toDTOs(
 					userAccountsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetUserAccountsPageUserAccount_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"userAccounts",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -9600,4 +9638,4 @@ public abstract class BaseUserAccountResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-82242425
+// LIFERAY-REST-BUILDER-HASH:816838257

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserGroupResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserGroupResourceTestCase.java
@@ -1435,17 +1435,8 @@ public abstract class BaseUserGroupResourceTestCase {
 
 	@Test
 	public void testGraphQLGetUserGroupsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"userGroups",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetUserGroupsPageUserGroup_getGraphQLField();
 
 		// No namespace
 
@@ -1500,6 +1491,23 @@ public abstract class BaseUserGroupResourceTestCase {
 			Arrays.asList(
 				UserGroupSerDes.toDTOs(
 					userGroupsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetUserGroupsPageUserGroup_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"userGroups",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3072,4 +3080,4 @@ public abstract class BaseUserGroupResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:961087040
+// LIFERAY-REST-BUILDER-HASH:-1610159096

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourceTest.java
@@ -802,6 +802,77 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		super.testGraphQLGetUserAccountsByStatusPage();
 	}
 
+	@Override
+	@Test
+	public void testGraphQLGetUserAccountsPage() throws Exception {
+		GraphQLField graphQLField = new GraphQLField(
+			"userAccounts",
+			new HashMap<String, Object>() {
+				{
+					put("page", 1);
+					put("pageSize", 10);
+					put("search", null);
+					put("sort", "\"dateCreated:desc\"");
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
+
+		// No namespace
+
+		JSONObject userAccountsJSONObject = JSONUtil.getValueAsJSONObject(
+			invokeGraphQLQuery(graphQLField), "JSONObject/data",
+			"JSONObject/userAccounts");
+
+		long totalCount = userAccountsJSONObject.getLong("totalCount");
+
+		UserAccount userAccount1 = testGraphQLUserAccount_addUserAccount(
+			randomUserAccount());
+
+		UserAccount userAccount2 = testGraphQLUserAccount_addUserAccount(
+			randomUserAccount());
+
+		userAccountsJSONObject = JSONUtil.getValueAsJSONObject(
+			invokeGraphQLQuery(graphQLField), "JSONObject/data",
+			"JSONObject/userAccounts");
+
+		Assert.assertEquals(
+			totalCount + 2, userAccountsJSONObject.getLong("totalCount"));
+
+		assertContains(
+			userAccount1,
+			Arrays.asList(
+				UserAccountSerDes.toDTOs(
+					userAccountsJSONObject.getString("items"))));
+		assertContains(
+			userAccount2,
+			Arrays.asList(
+				UserAccountSerDes.toDTOs(
+					userAccountsJSONObject.getString("items"))));
+
+		// Using the namespace headlessAdminUser_v1_0
+
+		userAccountsJSONObject = JSONUtil.getValueAsJSONObject(
+			invokeGraphQLQuery(
+				new GraphQLField("headlessAdminUser_v1_0", graphQLField)),
+			"JSONObject/data", "JSONObject/headlessAdminUser_v1_0",
+			"JSONObject/userAccounts");
+
+		Assert.assertEquals(
+			totalCount + 2, userAccountsJSONObject.getLong("totalCount"));
+
+		assertContains(
+			userAccount1,
+			Arrays.asList(
+				UserAccountSerDes.toDTOs(
+					userAccountsJSONObject.getString("items"))));
+		assertContains(
+			userAccount2,
+			Arrays.asList(
+				UserAccountSerDes.toDTOs(
+					userAccountsJSONObject.getString("items"))));
+	}
+
 	@Ignore
 	@Override
 	@Test

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourceTest.java
@@ -807,14 +807,15 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 	public void testGraphQLGetUserAccountsPage() throws Exception {
 		GraphQLField graphQLField = new GraphQLField(
 			"userAccounts",
-			new HashMap<String, Object>() {
-				{
-					put("page", 1);
-					put("pageSize", 10);
-					put("search", null);
-					put("sort", "\"dateCreated:desc\"");
-				}
-			},
+			HashMapBuilder.<String, Object>put(
+				"page", 1
+			).put(
+				"pageSize", 10
+			).put(
+				"search", () -> null
+			).put(
+				"sort", "\"dateCreated:desc\""
+			).build(),
 			new GraphQLField("items", getGraphQLFields()),
 			new GraphQLField("page"), new GraphQLField("totalCount"));
 
@@ -828,7 +829,6 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 
 		UserAccount userAccount1 = testGraphQLUserAccount_addUserAccount(
 			randomUserAccount());
-
 		UserAccount userAccount2 = testGraphQLUserAccount_addUserAccount(
 			randomUserAccount());
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourceTest.java
@@ -802,77 +802,6 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		super.testGraphQLGetUserAccountsByStatusPage();
 	}
 
-	@Override
-	@Test
-	public void testGraphQLGetUserAccountsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"userAccounts",
-			HashMapBuilder.<String, Object>put(
-				"page", 1
-			).put(
-				"pageSize", 10
-			).put(
-				"search", () -> null
-			).put(
-				"sort", "\"dateCreated:desc\""
-			).build(),
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
-
-		// No namespace
-
-		JSONObject userAccountsJSONObject = JSONUtil.getValueAsJSONObject(
-			invokeGraphQLQuery(graphQLField), "JSONObject/data",
-			"JSONObject/userAccounts");
-
-		long totalCount = userAccountsJSONObject.getLong("totalCount");
-
-		UserAccount userAccount1 = testGraphQLUserAccount_addUserAccount(
-			randomUserAccount());
-		UserAccount userAccount2 = testGraphQLUserAccount_addUserAccount(
-			randomUserAccount());
-
-		userAccountsJSONObject = JSONUtil.getValueAsJSONObject(
-			invokeGraphQLQuery(graphQLField), "JSONObject/data",
-			"JSONObject/userAccounts");
-
-		Assert.assertEquals(
-			totalCount + 2, userAccountsJSONObject.getLong("totalCount"));
-
-		assertContains(
-			userAccount1,
-			Arrays.asList(
-				UserAccountSerDes.toDTOs(
-					userAccountsJSONObject.getString("items"))));
-		assertContains(
-			userAccount2,
-			Arrays.asList(
-				UserAccountSerDes.toDTOs(
-					userAccountsJSONObject.getString("items"))));
-
-		// Using the namespace headlessAdminUser_v1_0
-
-		userAccountsJSONObject = JSONUtil.getValueAsJSONObject(
-			invokeGraphQLQuery(
-				new GraphQLField("headlessAdminUser_v1_0", graphQLField)),
-			"JSONObject/data", "JSONObject/headlessAdminUser_v1_0",
-			"JSONObject/userAccounts");
-
-		Assert.assertEquals(
-			totalCount + 2, userAccountsJSONObject.getLong("totalCount"));
-
-		assertContains(
-			userAccount1,
-			Arrays.asList(
-				UserAccountSerDes.toDTOs(
-					userAccountsJSONObject.getString("items"))));
-		assertContains(
-			userAccount2,
-			Arrays.asList(
-				UserAccountSerDes.toDTOs(
-					userAccountsJSONObject.getString("items"))));
-	}
-
 	@Ignore
 	@Override
 	@Test
@@ -1842,6 +1771,26 @@ public class UserAccountResourceTest extends BaseUserAccountResourceTestCase {
 		throws Exception {
 
 		return _accountEntry.getAccountEntryId();
+	}
+
+	@Override
+	protected GraphQLField
+			testGraphQLGetUserAccountsPageUserAccount_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"userAccounts",
+			HashMapBuilder.<String, Object>put(
+				"page", 1
+			).put(
+				"pageSize", 10
+			).put(
+				"search", () -> null
+			).put(
+				"sort", "\"dateCreated:desc\""
+			).build(),
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowDefinitionLinkResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowDefinitionLinkResourceTestCase.java
@@ -653,17 +653,9 @@ public abstract class BaseWorkflowDefinitionLinkResourceTestCase {
 		Long workflowDefinitionId =
 			testGetWorkflowDefinitionWorkflowDefinitionLinksPage_getWorkflowDefinitionId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"workflowDefinitionWorkflowDefinitionLinks",
-			new HashMap<String, Object>() {
-				{
-					put("workflowDefinitionId", workflowDefinitionId);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetWorkflowDefinitionWorkflowDefinitionLinksPageWorkflowDefinitionWorkflowDefinitionLink_getGraphQLField(
+				workflowDefinitionId);
 
 		// No namespace
 
@@ -734,6 +726,24 @@ public abstract class BaseWorkflowDefinitionLinkResourceTestCase {
 				WorkflowDefinitionLinkSerDes.toDTOs(
 					workflowDefinitionWorkflowDefinitionLinksJSONObject.
 						getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetWorkflowDefinitionWorkflowDefinitionLinksPageWorkflowDefinitionWorkflowDefinitionLink_getGraphQLField(
+				Long workflowDefinitionId)
+		throws Exception {
+
+		return new GraphQLField(
+			"workflowDefinitionWorkflowDefinitionLinks",
+			new HashMap<String, Object>() {
+				{
+					put("workflowDefinitionId", workflowDefinitionId);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -1997,4 +2007,4 @@ public abstract class BaseWorkflowDefinitionLinkResourceTestCase {
 		WorkflowDefinitionLinkResource _workflowDefinitionLinkResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-947174397
+// LIFERAY-REST-BUILDER-HASH:-890742207

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowDefinitionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowDefinitionResourceTestCase.java
@@ -1191,19 +1191,8 @@ public abstract class BaseWorkflowDefinitionResourceTestCase {
 
 	@Test
 	public void testGraphQLGetWorkflowDefinitionsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"workflowDefinitions",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"scope",
-						getGraphQLValue(RandomTestUtil.randomString()));
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetWorkflowDefinitionsPageWorkflowDefinition_getGraphQLField();
 
 		// No namespace
 
@@ -1263,6 +1252,25 @@ public abstract class BaseWorkflowDefinitionResourceTestCase {
 			Arrays.asList(
 				WorkflowDefinitionSerDes.toDTOs(
 					workflowDefinitionsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetWorkflowDefinitionsPageWorkflowDefinition_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"workflowDefinitions",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"scope",
+						getGraphQLValue(RandomTestUtil.randomString()));
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3057,4 +3065,4 @@ public abstract class BaseWorkflowDefinitionResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1681011371
+// LIFERAY-REST-BUILDER-HASH:-564609211

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
@@ -1518,18 +1518,9 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 	public void testGraphQLGetSiteBlogPostingImagesPage() throws Exception {
 		Long siteId = testGetSiteBlogPostingImagesPage_getSiteId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"blogPostingImages",
-			new HashMap<String, Object>() {
-				{
-					put("siteKey", "\"" + siteId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteBlogPostingImagesPageSiteBlogPostingImage_getGraphQLField(
+				siteId);
 
 		// No namespace
 
@@ -1586,6 +1577,25 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 			Arrays.asList(
 				BlogPostingImageSerDes.toDTOs(
 					blogPostingImagesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteBlogPostingImagesPageSiteBlogPostingImage_getGraphQLField(
+				Long siteId)
+		throws Exception {
+
+		return new GraphQLField(
+			"blogPostingImages",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3015,4 +3025,4 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-743896481
+// LIFERAY-REST-BUILDER-HASH:-196558501

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
@@ -1773,18 +1773,9 @@ public abstract class BaseBlogPostingResourceTestCase {
 	public void testGraphQLGetSiteBlogPostingsPage() throws Exception {
 		Long siteId = testGetSiteBlogPostingsPage_getSiteId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"blogPostings",
-			new HashMap<String, Object>() {
-				{
-					put("siteKey", "\"" + siteId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteBlogPostingsPageSiteBlogPosting_getGraphQLField(
+				siteId);
 
 		// No namespace
 
@@ -1839,6 +1830,25 @@ public abstract class BaseBlogPostingResourceTestCase {
 			Arrays.asList(
 				BlogPostingSerDes.toDTOs(
 					blogPostingsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteBlogPostingsPageSiteBlogPosting_getGraphQLField(
+				Long siteId)
+		throws Exception {
+
+		return new GraphQLField(
+			"blogPostings",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -4197,4 +4207,4 @@ public abstract class BaseBlogPostingResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:198534329
+// LIFERAY-REST-BUILDER-HASH:-839133491

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
@@ -1592,18 +1592,9 @@ public abstract class BaseCommentResourceTestCase {
 	public void testGraphQLGetBlogPostingCommentsPage() throws Exception {
 		Long blogPostingId = testGetBlogPostingCommentsPage_getBlogPostingId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"blogPostingComments",
-			new HashMap<String, Object>() {
-				{
-					put("blogPostingId", blogPostingId);
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetBlogPostingCommentsPageBlogPostingComment_getGraphQLField(
+				blogPostingId);
 
 		// No namespace
 
@@ -1661,6 +1652,25 @@ public abstract class BaseCommentResourceTestCase {
 			Arrays.asList(
 				CommentSerDes.toDTOs(
 					blogPostingCommentsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetBlogPostingCommentsPageBlogPostingComment_getGraphQLField(
+				Long blogPostingId)
+		throws Exception {
+
+		return new GraphQLField(
+			"blogPostingComments",
+			new HashMap<String, Object>() {
+				{
+					put("blogPostingId", blogPostingId);
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2735,18 +2745,9 @@ public abstract class BaseCommentResourceTestCase {
 	public void testGraphQLGetDocumentCommentsPage() throws Exception {
 		Long documentId = testGetDocumentCommentsPage_getDocumentId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"documentComments",
-			new HashMap<String, Object>() {
-				{
-					put("documentId", documentId);
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetDocumentCommentsPageDocumentComment_getGraphQLField(
+				documentId);
 
 		// No namespace
 
@@ -2801,6 +2802,25 @@ public abstract class BaseCommentResourceTestCase {
 			Arrays.asList(
 				CommentSerDes.toDTOs(
 					documentCommentsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetDocumentCommentsPageDocumentComment_getGraphQLField(
+				Long documentId)
+		throws Exception {
+
+		return new GraphQLField(
+			"documentComments",
+			new HashMap<String, Object>() {
+				{
+					put("documentId", documentId);
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -4044,18 +4064,9 @@ public abstract class BaseCommentResourceTestCase {
 		Long structuredContentId =
 			testGetStructuredContentCommentsPage_getStructuredContentId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"structuredContentComments",
-			new HashMap<String, Object>() {
-				{
-					put("structuredContentId", structuredContentId);
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetStructuredContentCommentsPageStructuredContentComment_getGraphQLField(
+				structuredContentId);
 
 		// No namespace
 
@@ -4114,6 +4125,25 @@ public abstract class BaseCommentResourceTestCase {
 			Arrays.asList(
 				CommentSerDes.toDTOs(
 					structuredContentCommentsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetStructuredContentCommentsPageStructuredContentComment_getGraphQLField(
+				Long structuredContentId)
+		throws Exception {
+
+		return new GraphQLField(
+			"structuredContentComments",
+			new HashMap<String, Object>() {
+				{
+					put("structuredContentId", structuredContentId);
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -5927,4 +5957,4 @@ public abstract class BaseCommentResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1319366438
+// LIFERAY-REST-BUILDER-HASH:1074758882

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentDataDefinitionTypeResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentDataDefinitionTypeResourceTestCase.java
@@ -968,18 +968,9 @@ public abstract class BaseDocumentDataDefinitionTypeResourceTestCase {
 		Long assetLibraryId =
 			testGetAssetLibraryDocumentDataDefinitionTypesPage_getAssetLibraryId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"assetLibraryDocumentDataDefinitionTypes",
-			new HashMap<String, Object>() {
-				{
-					put("assetLibraryId", "\"" + assetLibraryId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAssetLibraryDocumentDataDefinitionTypesPageAssetLibraryDocumentDataDefinitionType_getGraphQLField(
+				assetLibraryId);
 
 		// No namespace
 
@@ -1049,6 +1040,25 @@ public abstract class BaseDocumentDataDefinitionTypeResourceTestCase {
 				DocumentDataDefinitionTypeSerDes.toDTOs(
 					assetLibraryDocumentDataDefinitionTypesJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetAssetLibraryDocumentDataDefinitionTypesPageAssetLibraryDocumentDataDefinitionType_getGraphQLField(
+				Long assetLibraryId)
+		throws Exception {
+
+		return new GraphQLField(
+			"assetLibraryDocumentDataDefinitionTypes",
+			new HashMap<String, Object>() {
+				{
+					put("assetLibraryId", "\"" + assetLibraryId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -1894,18 +1904,9 @@ public abstract class BaseDocumentDataDefinitionTypeResourceTestCase {
 
 		Long siteId = testGetSiteDocumentDataDefinitionTypesPage_getSiteId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"documentDataDefinitionTypes",
-			new HashMap<String, Object>() {
-				{
-					put("siteKey", "\"" + siteId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteDocumentDataDefinitionTypesPageSiteDocumentDataDefinitionType_getGraphQLField(
+				siteId);
 
 		// No namespace
 
@@ -1966,6 +1967,25 @@ public abstract class BaseDocumentDataDefinitionTypeResourceTestCase {
 			Arrays.asList(
 				DocumentDataDefinitionTypeSerDes.toDTOs(
 					documentDataDefinitionTypesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteDocumentDataDefinitionTypesPageSiteDocumentDataDefinitionType_getGraphQLField(
+				Long siteId)
+		throws Exception {
+
+		return new GraphQLField(
+			"documentDataDefinitionTypes",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3675,4 +3695,4 @@ public abstract class BaseDocumentDataDefinitionTypeResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1096544727
+// LIFERAY-REST-BUILDER-HASH:-168857583

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
@@ -1218,18 +1218,9 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		Long assetLibraryId =
 			testGetAssetLibraryDocumentFoldersPage_getAssetLibraryId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"assetLibraryDocumentFolders",
-			new HashMap<String, Object>() {
-				{
-					put("assetLibraryId", "\"" + assetLibraryId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAssetLibraryDocumentFoldersPageAssetLibraryDocumentFolder_getGraphQLField(
+				assetLibraryId);
 
 		// No namespace
 
@@ -1290,6 +1281,25 @@ public abstract class BaseDocumentFolderResourceTestCase {
 			Arrays.asList(
 				DocumentFolderSerDes.toDTOs(
 					assetLibraryDocumentFoldersJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetAssetLibraryDocumentFoldersPageAssetLibraryDocumentFolder_getGraphQLField(
+				Long assetLibraryId)
+		throws Exception {
+
+		return new GraphQLField(
+			"assetLibraryDocumentFolders",
+			new HashMap<String, Object>() {
+				{
+					put("assetLibraryId", "\"" + assetLibraryId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -1501,17 +1511,9 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		Long assetLibraryId =
 			testGetAssetLibraryDocumentFoldersRatedByMePage_getAssetLibraryId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"assetLibraryDocumentFoldersRatedByMe",
-			new HashMap<String, Object>() {
-				{
-					put("assetLibraryId", "\"" + assetLibraryId + "\"");
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAssetLibraryDocumentFoldersRatedByMePageAssetLibraryDocumentFolder_getGraphQLField(
+				assetLibraryId);
 
 		// No namespace
 
@@ -1581,6 +1583,24 @@ public abstract class BaseDocumentFolderResourceTestCase {
 				DocumentFolderSerDes.toDTOs(
 					assetLibraryDocumentFoldersRatedByMeJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetAssetLibraryDocumentFoldersRatedByMePageAssetLibraryDocumentFolder_getGraphQLField(
+				Long assetLibraryId)
+		throws Exception {
+
+		return new GraphQLField(
+			"assetLibraryDocumentFoldersRatedByMe",
+			new HashMap<String, Object>() {
+				{
+					put("assetLibraryId", "\"" + assetLibraryId + "\"");
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2365,18 +2385,9 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		Long parentDocumentFolderId =
 			testGetDocumentFolderDocumentFoldersPage_getParentDocumentFolderId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"documentFolderDocumentFolders",
-			new HashMap<String, Object>() {
-				{
-					put("parentDocumentFolderId", parentDocumentFolderId);
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetDocumentFolderDocumentFoldersPageDocumentFolder_getGraphQLField(
+				parentDocumentFolderId);
 
 		// No namespace
 
@@ -2441,6 +2452,25 @@ public abstract class BaseDocumentFolderResourceTestCase {
 				DocumentFolderSerDes.toDTOs(
 					documentFolderDocumentFoldersJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetDocumentFolderDocumentFoldersPageDocumentFolder_getGraphQLField(
+				Long parentDocumentFolderId)
+		throws Exception {
+
+		return new GraphQLField(
+			"documentFolderDocumentFolders",
+			new HashMap<String, Object>() {
+				{
+					put("parentDocumentFolderId", parentDocumentFolderId);
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected DocumentFolder
@@ -3006,18 +3036,9 @@ public abstract class BaseDocumentFolderResourceTestCase {
 	public void testGraphQLGetSiteDocumentFoldersPage() throws Exception {
 		Long siteId = testGetSiteDocumentFoldersPage_getSiteId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"documentFolders",
-			new HashMap<String, Object>() {
-				{
-					put("siteKey", "\"" + siteId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteDocumentFoldersPageSiteDocumentFolder_getGraphQLField(
+				siteId);
 
 		// No namespace
 
@@ -3074,6 +3095,25 @@ public abstract class BaseDocumentFolderResourceTestCase {
 			Arrays.asList(
 				DocumentFolderSerDes.toDTOs(
 					documentFoldersJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteDocumentFoldersPageSiteDocumentFolder_getGraphQLField(
+				Long siteId)
+		throws Exception {
+
+		return new GraphQLField(
+			"documentFolders",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3267,17 +3307,9 @@ public abstract class BaseDocumentFolderResourceTestCase {
 
 		Long siteId = testGetSiteDocumentFoldersRatedByMePage_getSiteId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"documentFoldersRatedByMe",
-			new HashMap<String, Object>() {
-				{
-					put("siteKey", "\"" + siteId + "\"");
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteDocumentFoldersRatedByMePageSiteDocumentFolder_getGraphQLField(
+				siteId);
 
 		// No namespace
 
@@ -3338,6 +3370,24 @@ public abstract class BaseDocumentFolderResourceTestCase {
 			Arrays.asList(
 				DocumentFolderSerDes.toDTOs(
 					documentFoldersRatedByMeJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteDocumentFoldersRatedByMePageSiteDocumentFolder_getGraphQLField(
+				Long siteId)
+		throws Exception {
+
+		return new GraphQLField(
+			"documentFoldersRatedByMe",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -5685,4 +5735,4 @@ public abstract class BaseDocumentFolderResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1764022323
+// LIFERAY-REST-BUILDER-HASH:2117197097

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentMetadataSetResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentMetadataSetResourceTestCase.java
@@ -1146,17 +1146,9 @@ public abstract class BaseDocumentMetadataSetResourceTestCase {
 		Long assetLibraryId =
 			testGetAssetLibraryDocumentMetadataSetsPage_getAssetLibraryId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"assetLibraryDocumentMetadataSets",
-			new HashMap<String, Object>() {
-				{
-					put("assetLibraryId", "\"" + assetLibraryId + "\"");
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAssetLibraryDocumentMetadataSetsPageAssetLibraryDocumentMetadataSet_getGraphQLField(
+				assetLibraryId);
 
 		// No namespace
 
@@ -1223,6 +1215,24 @@ public abstract class BaseDocumentMetadataSetResourceTestCase {
 				DocumentMetadataSetSerDes.toDTOs(
 					assetLibraryDocumentMetadataSetsJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetAssetLibraryDocumentMetadataSetsPageAssetLibraryDocumentMetadataSet_getGraphQLField(
+				Long assetLibraryId)
+		throws Exception {
+
+		return new GraphQLField(
+			"assetLibraryDocumentMetadataSets",
+			new HashMap<String, Object>() {
+				{
+					put("assetLibraryId", "\"" + assetLibraryId + "\"");
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -1911,17 +1921,9 @@ public abstract class BaseDocumentMetadataSetResourceTestCase {
 	public void testGraphQLGetSiteDocumentMetadataSetsPage() throws Exception {
 		Long siteId = testGetSiteDocumentMetadataSetsPage_getSiteId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"documentMetadataSets",
-			new HashMap<String, Object>() {
-				{
-					put("siteKey", "\"" + siteId + "\"");
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteDocumentMetadataSetsPageSiteDocumentMetadataSet_getGraphQLField(
+				siteId);
 
 		// No namespace
 
@@ -1981,6 +1983,24 @@ public abstract class BaseDocumentMetadataSetResourceTestCase {
 			Arrays.asList(
 				DocumentMetadataSetSerDes.toDTOs(
 					documentMetadataSetsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteDocumentMetadataSetsPageSiteDocumentMetadataSet_getGraphQLField(
+				Long siteId)
+		throws Exception {
+
+		return new GraphQLField(
+			"documentMetadataSets",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3789,4 +3809,4 @@ public abstract class BaseDocumentMetadataSetResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1680640719
+// LIFERAY-REST-BUILDER-HASH:1050077563

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -1492,18 +1492,9 @@ public abstract class BaseDocumentResourceTestCase {
 		Long assetLibraryId =
 			testGetAssetLibraryDocumentsPage_getAssetLibraryId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"assetLibraryDocuments",
-			new HashMap<String, Object>() {
-				{
-					put("assetLibraryId", "\"" + assetLibraryId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAssetLibraryDocumentsPageAssetLibraryDocument_getGraphQLField(
+				assetLibraryId);
 
 		// No namespace
 
@@ -1561,6 +1552,25 @@ public abstract class BaseDocumentResourceTestCase {
 			Arrays.asList(
 				DocumentSerDes.toDTOs(
 					assetLibraryDocumentsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetAssetLibraryDocumentsPageAssetLibraryDocument_getGraphQLField(
+				Long assetLibraryId)
+		throws Exception {
+
+		return new GraphQLField(
+			"assetLibraryDocuments",
+			new HashMap<String, Object>() {
+				{
+					put("assetLibraryId", "\"" + assetLibraryId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -1746,17 +1756,9 @@ public abstract class BaseDocumentResourceTestCase {
 		Long assetLibraryId =
 			testGetAssetLibraryDocumentsRatedByMePage_getAssetLibraryId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"assetLibraryDocumentsRatedByMe",
-			new HashMap<String, Object>() {
-				{
-					put("assetLibraryId", "\"" + assetLibraryId + "\"");
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAssetLibraryDocumentsRatedByMePageAssetLibraryDocument_getGraphQLField(
+				assetLibraryId);
 
 		// No namespace
 
@@ -1821,6 +1823,24 @@ public abstract class BaseDocumentResourceTestCase {
 				DocumentSerDes.toDTOs(
 					assetLibraryDocumentsRatedByMeJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetAssetLibraryDocumentsRatedByMePageAssetLibraryDocument_getGraphQLField(
+				Long assetLibraryId)
+		throws Exception {
+
+		return new GraphQLField(
+			"assetLibraryDocumentsRatedByMe",
+			new HashMap<String, Object>() {
+				{
+					put("assetLibraryId", "\"" + assetLibraryId + "\"");
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2557,18 +2577,9 @@ public abstract class BaseDocumentResourceTestCase {
 		Long documentFolderId =
 			testGetDocumentFolderDocumentsPage_getDocumentFolderId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"documentFolderDocuments",
-			new HashMap<String, Object>() {
-				{
-					put("documentFolderId", documentFolderId);
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetDocumentFolderDocumentsPageDocumentFolderDocument_getGraphQLField(
+				documentFolderId);
 
 		// No namespace
 
@@ -2627,6 +2638,25 @@ public abstract class BaseDocumentResourceTestCase {
 			Arrays.asList(
 				DocumentSerDes.toDTOs(
 					documentFolderDocumentsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetDocumentFolderDocumentsPageDocumentFolderDocument_getGraphQLField(
+				Long documentFolderId)
+		throws Exception {
+
+		return new GraphQLField(
+			"documentFolderDocuments",
+			new HashMap<String, Object>() {
+				{
+					put("documentFolderId", documentFolderId);
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3266,18 +3296,8 @@ public abstract class BaseDocumentResourceTestCase {
 	public void testGraphQLGetSiteDocumentsPage() throws Exception {
 		Long siteId = testGetSiteDocumentsPage_getSiteId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"documents",
-			new HashMap<String, Object>() {
-				{
-					put("siteKey", "\"" + siteId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteDocumentsPageSiteDocument_getGraphQLField(siteId);
 
 		// No namespace
 
@@ -3328,6 +3348,25 @@ public abstract class BaseDocumentResourceTestCase {
 			document2,
 			Arrays.asList(
 				DocumentSerDes.toDTOs(documentsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteDocumentsPageSiteDocument_getGraphQLField(
+				Long siteId)
+		throws Exception {
+
+		return new GraphQLField(
+			"documents",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3496,17 +3535,9 @@ public abstract class BaseDocumentResourceTestCase {
 	public void testGraphQLGetSiteDocumentsRatedByMePage() throws Exception {
 		Long siteId = testGetSiteDocumentsRatedByMePage_getSiteId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"documentsRatedByMe",
-			new HashMap<String, Object>() {
-				{
-					put("siteKey", "\"" + siteId + "\"");
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteDocumentsRatedByMePageSiteDocument_getGraphQLField(
+				siteId);
 
 		// No namespace
 
@@ -3561,6 +3592,24 @@ public abstract class BaseDocumentResourceTestCase {
 			Arrays.asList(
 				DocumentSerDes.toDTOs(
 					documentsRatedByMeJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteDocumentsRatedByMePageSiteDocument_getGraphQLField(
+				Long siteId)
+		throws Exception {
+
+		return new GraphQLField(
+			"documentsRatedByMe",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -6583,4 +6632,4 @@ public abstract class BaseDocumentResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-293638472
+// LIFERAY-REST-BUILDER-HASH:993960568

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentShortcutResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentShortcutResourceTestCase.java
@@ -780,17 +780,9 @@ public abstract class BaseDocumentShortcutResourceTestCase {
 		Long assetLibraryId =
 			testGetAssetLibraryDocumentShortcutsPage_getAssetLibraryId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"assetLibraryDocumentShortcuts",
-			new HashMap<String, Object>() {
-				{
-					put("assetLibraryId", "\"" + assetLibraryId + "\"");
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAssetLibraryDocumentShortcutsPageAssetLibraryDocumentShortcut_getGraphQLField(
+				assetLibraryId);
 
 		// No namespace
 
@@ -855,6 +847,24 @@ public abstract class BaseDocumentShortcutResourceTestCase {
 				DocumentShortcutSerDes.toDTOs(
 					assetLibraryDocumentShortcutsJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetAssetLibraryDocumentShortcutsPageAssetLibraryDocumentShortcut_getGraphQLField(
+				Long assetLibraryId)
+		throws Exception {
+
+		return new GraphQLField(
+			"assetLibraryDocumentShortcuts",
+			new HashMap<String, Object>() {
+				{
+					put("assetLibraryId", "\"" + assetLibraryId + "\"");
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -1532,17 +1542,9 @@ public abstract class BaseDocumentShortcutResourceTestCase {
 	public void testGraphQLGetSiteDocumentShortcutsPage() throws Exception {
 		Long siteId = testGetSiteDocumentShortcutsPage_getSiteId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"documentShortcuts",
-			new HashMap<String, Object>() {
-				{
-					put("siteKey", "\"" + siteId + "\"");
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteDocumentShortcutsPageSiteDocumentShortcut_getGraphQLField(
+				siteId);
 
 		// No namespace
 
@@ -1599,6 +1601,24 @@ public abstract class BaseDocumentShortcutResourceTestCase {
 			Arrays.asList(
 				DocumentShortcutSerDes.toDTOs(
 					documentShortcutsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteDocumentShortcutsPageSiteDocumentShortcut_getGraphQLField(
+				Long siteId)
+		throws Exception {
+
+		return new GraphQLField(
+			"documentShortcuts",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3192,4 +3212,4 @@ public abstract class BaseDocumentShortcutResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1902295865
+// LIFERAY-REST-BUILDER-HASH:1242620895

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
@@ -1510,20 +1510,9 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		Long parentKnowledgeBaseArticleId =
 			testGetKnowledgeBaseArticleKnowledgeBaseArticlesPage_getParentKnowledgeBaseArticleId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"knowledgeBaseArticleKnowledgeBaseArticles",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"parentKnowledgeBaseArticleId",
-						parentKnowledgeBaseArticleId);
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetKnowledgeBaseArticleKnowledgeBaseArticlesPageKnowledgeBaseArticle_getGraphQLField(
+				parentKnowledgeBaseArticleId);
 
 		// No namespace
 
@@ -1593,6 +1582,27 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 				KnowledgeBaseArticleSerDes.toDTOs(
 					knowledgeBaseArticleKnowledgeBaseArticlesJSONObject.
 						getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetKnowledgeBaseArticleKnowledgeBaseArticlesPageKnowledgeBaseArticle_getGraphQLField(
+				Long parentKnowledgeBaseArticleId)
+		throws Exception {
+
+		return new GraphQLField(
+			"knowledgeBaseArticleKnowledgeBaseArticles",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"parentKnowledgeBaseArticleId",
+						parentKnowledgeBaseArticleId);
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected KnowledgeBaseArticle
@@ -2177,18 +2187,9 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		Long knowledgeBaseFolderId =
 			testGetKnowledgeBaseFolderKnowledgeBaseArticlesPage_getKnowledgeBaseFolderId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"knowledgeBaseFolderKnowledgeBaseArticles",
-			new HashMap<String, Object>() {
-				{
-					put("knowledgeBaseFolderId", knowledgeBaseFolderId);
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetKnowledgeBaseFolderKnowledgeBaseArticlesPageKnowledgeBaseFolderKnowledgeBaseArticle_getGraphQLField(
+				knowledgeBaseFolderId);
 
 		// No namespace
 
@@ -2258,6 +2259,25 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 				KnowledgeBaseArticleSerDes.toDTOs(
 					knowledgeBaseFolderKnowledgeBaseArticlesJSONObject.
 						getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetKnowledgeBaseFolderKnowledgeBaseArticlesPageKnowledgeBaseFolderKnowledgeBaseArticle_getGraphQLField(
+				Long knowledgeBaseFolderId)
+		throws Exception {
+
+		return new GraphQLField(
+			"knowledgeBaseFolderKnowledgeBaseArticles",
+			new HashMap<String, Object>() {
+				{
+					put("knowledgeBaseFolderId", knowledgeBaseFolderId);
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2951,18 +2971,9 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 	public void testGraphQLGetSiteKnowledgeBaseArticlesPage() throws Exception {
 		Long siteId = testGetSiteKnowledgeBaseArticlesPage_getSiteId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"knowledgeBaseArticles",
-			new HashMap<String, Object>() {
-				{
-					put("siteKey", "\"" + siteId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteKnowledgeBaseArticlesPageSiteKnowledgeBaseArticle_getGraphQLField(
+				siteId);
 
 		// No namespace
 
@@ -3022,6 +3033,25 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 			Arrays.asList(
 				KnowledgeBaseArticleSerDes.toDTOs(
 					knowledgeBaseArticlesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteKnowledgeBaseArticlesPageSiteKnowledgeBaseArticle_getGraphQLField(
+				Long siteId)
+		throws Exception {
+
+		return new GraphQLField(
+			"knowledgeBaseArticles",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -5728,4 +5758,4 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1532918089
+// LIFERAY-REST-BUILDER-HASH:-93206707

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
@@ -747,15 +747,9 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 		Long knowledgeBaseArticleId =
 			testGetKnowledgeBaseArticleKnowledgeBaseAttachmentsPage_getKnowledgeBaseArticleId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"knowledgeBaseArticleKnowledgeBaseAttachments",
-			new HashMap<String, Object>() {
-				{
-					put("knowledgeBaseArticleId", knowledgeBaseArticleId);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetKnowledgeBaseArticleKnowledgeBaseAttachmentsPageKnowledgeBaseArticleKnowledgeBaseAttachment_getGraphQLField(
+				knowledgeBaseArticleId);
 
 		// No namespace
 
@@ -825,6 +819,22 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 				KnowledgeBaseAttachmentSerDes.toDTOs(
 					knowledgeBaseArticleKnowledgeBaseAttachmentsJSONObject.
 						getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetKnowledgeBaseArticleKnowledgeBaseAttachmentsPageKnowledgeBaseArticleKnowledgeBaseAttachment_getGraphQLField(
+				Long knowledgeBaseArticleId)
+		throws Exception {
+
+		return new GraphQLField(
+			"knowledgeBaseArticleKnowledgeBaseAttachments",
+			new HashMap<String, Object>() {
+				{
+					put("knowledgeBaseArticleId", knowledgeBaseArticleId);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2726,4 +2736,4 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:589176070
+// LIFERAY-REST-BUILDER-HASH:275806126

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
@@ -1096,19 +1096,9 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		Long parentKnowledgeBaseFolderId =
 			testGetKnowledgeBaseFolderKnowledgeBaseFoldersPage_getParentKnowledgeBaseFolderId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"knowledgeBaseFolderKnowledgeBaseFolders",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"parentKnowledgeBaseFolderId",
-						parentKnowledgeBaseFolderId);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetKnowledgeBaseFolderKnowledgeBaseFoldersPageKnowledgeBaseFolder_getGraphQLField(
+				parentKnowledgeBaseFolderId);
 
 		// No namespace
 
@@ -1178,6 +1168,26 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 				KnowledgeBaseFolderSerDes.toDTOs(
 					knowledgeBaseFolderKnowledgeBaseFoldersJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetKnowledgeBaseFolderKnowledgeBaseFoldersPageKnowledgeBaseFolder_getGraphQLField(
+				Long parentKnowledgeBaseFolderId)
+		throws Exception {
+
+		return new GraphQLField(
+			"knowledgeBaseFolderKnowledgeBaseFolders",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"parentKnowledgeBaseFolderId",
+						parentKnowledgeBaseFolderId);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected KnowledgeBaseFolder
@@ -1667,17 +1677,9 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 	public void testGraphQLGetSiteKnowledgeBaseFoldersPage() throws Exception {
 		Long siteId = testGetSiteKnowledgeBaseFoldersPage_getSiteId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"knowledgeBaseFolders",
-			new HashMap<String, Object>() {
-				{
-					put("siteKey", "\"" + siteId + "\"");
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteKnowledgeBaseFoldersPageSiteKnowledgeBaseFolder_getGraphQLField(
+				siteId);
 
 		// No namespace
 
@@ -1737,6 +1739,24 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 			Arrays.asList(
 				KnowledgeBaseFolderSerDes.toDTOs(
 					knowledgeBaseFoldersJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteKnowledgeBaseFoldersPageSiteKnowledgeBaseFolder_getGraphQLField(
+				Long siteId)
+		throws Exception {
+
+		return new GraphQLField(
+			"knowledgeBaseFolders",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3543,4 +3563,4 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1393798312
+// LIFERAY-REST-BUILDER-HASH:708956350

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
@@ -1070,15 +1070,9 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 		Long messageBoardMessageId =
 			testGetMessageBoardMessageMessageBoardAttachmentsPage_getMessageBoardMessageId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"messageBoardMessageMessageBoardAttachments",
-			new HashMap<String, Object>() {
-				{
-					put("messageBoardMessageId", messageBoardMessageId);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetMessageBoardMessageMessageBoardAttachmentsPageMessageBoardMessageMessageBoardAttachment_getGraphQLField(
+				messageBoardMessageId);
 
 		// No namespace
 
@@ -1148,6 +1142,22 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 				MessageBoardAttachmentSerDes.toDTOs(
 					messageBoardMessageMessageBoardAttachmentsJSONObject.
 						getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetMessageBoardMessageMessageBoardAttachmentsPageMessageBoardMessageMessageBoardAttachment_getGraphQLField(
+				Long messageBoardMessageId)
+		throws Exception {
+
+		return new GraphQLField(
+			"messageBoardMessageMessageBoardAttachments",
+			new HashMap<String, Object>() {
+				{
+					put("messageBoardMessageId", messageBoardMessageId);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -1277,15 +1287,9 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 		Long messageBoardThreadId =
 			testGetMessageBoardThreadMessageBoardAttachmentsPage_getMessageBoardThreadId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"messageBoardThreadMessageBoardAttachments",
-			new HashMap<String, Object>() {
-				{
-					put("messageBoardThreadId", messageBoardThreadId);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetMessageBoardThreadMessageBoardAttachmentsPageMessageBoardThreadMessageBoardAttachment_getGraphQLField(
+				messageBoardThreadId);
 
 		// No namespace
 
@@ -1355,6 +1359,22 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 				MessageBoardAttachmentSerDes.toDTOs(
 					messageBoardThreadMessageBoardAttachmentsJSONObject.
 						getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetMessageBoardThreadMessageBoardAttachmentsPageMessageBoardThreadMessageBoardAttachment_getGraphQLField(
+				Long messageBoardThreadId)
+		throws Exception {
+
+		return new GraphQLField(
+			"messageBoardThreadMessageBoardAttachments",
+			new HashMap<String, Object>() {
+				{
+					put("messageBoardThreadId", messageBoardThreadId);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3042,4 +3062,4 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1321063250
+// LIFERAY-REST-BUILDER-HASH:-1820335740

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
@@ -2025,18 +2025,9 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		Long messageBoardThreadId =
 			testGetMessageBoardThreadMessageBoardMessagesPage_getMessageBoardThreadId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"messageBoardThreadMessageBoardMessages",
-			new HashMap<String, Object>() {
-				{
-					put("messageBoardThreadId", messageBoardThreadId);
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetMessageBoardThreadMessageBoardMessagesPageMessageBoardThreadMessageBoardMessage_getGraphQLField(
+				messageBoardThreadId);
 
 		// No namespace
 
@@ -2106,6 +2097,25 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 				MessageBoardMessageSerDes.toDTOs(
 					messageBoardThreadMessageBoardMessagesJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetMessageBoardThreadMessageBoardMessagesPageMessageBoardThreadMessageBoardMessage_getGraphQLField(
+				Long messageBoardThreadId)
+		throws Exception {
+
+		return new GraphQLField(
+			"messageBoardThreadMessageBoardMessages",
+			new HashMap<String, Object>() {
+				{
+					put("messageBoardThreadId", messageBoardThreadId);
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -5720,4 +5730,4 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-788315504
+// LIFERAY-REST-BUILDER-HASH:-778766806

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
@@ -1217,20 +1217,9 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		Long parentMessageBoardSectionId =
 			testGetMessageBoardSectionMessageBoardSectionsPage_getParentMessageBoardSectionId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"messageBoardSectionMessageBoardSections",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"parentMessageBoardSectionId",
-						parentMessageBoardSectionId);
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetMessageBoardSectionMessageBoardSectionsPageMessageBoardSection_getGraphQLField(
+				parentMessageBoardSectionId);
 
 		// No namespace
 
@@ -1300,6 +1289,27 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 				MessageBoardSectionSerDes.toDTOs(
 					messageBoardSectionMessageBoardSectionsJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetMessageBoardSectionMessageBoardSectionsPageMessageBoardSection_getGraphQLField(
+				Long parentMessageBoardSectionId)
+		throws Exception {
+
+		return new GraphQLField(
+			"messageBoardSectionMessageBoardSections",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"parentMessageBoardSectionId",
+						parentMessageBoardSectionId);
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected MessageBoardSection
@@ -2054,18 +2064,9 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 	public void testGraphQLGetSiteMessageBoardSectionsPage() throws Exception {
 		Long siteId = testGetSiteMessageBoardSectionsPage_getSiteId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"messageBoardSections",
-			new HashMap<String, Object>() {
-				{
-					put("siteKey", "\"" + siteId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteMessageBoardSectionsPageSiteMessageBoardSection_getGraphQLField(
+				siteId);
 
 		// No namespace
 
@@ -2125,6 +2126,25 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 			Arrays.asList(
 				MessageBoardSectionSerDes.toDTOs(
 					messageBoardSectionsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteMessageBoardSectionsPageSiteMessageBoardSection_getGraphQLField(
+				Long siteId)
+		throws Exception {
+
+		return new GraphQLField(
+			"messageBoardSections",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3860,4 +3880,4 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-539812710
+// LIFERAY-REST-BUILDER-HASH:460151248

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
@@ -1033,18 +1033,9 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		Long messageBoardSectionId =
 			testGetMessageBoardSectionMessageBoardThreadsPage_getMessageBoardSectionId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"messageBoardSectionMessageBoardThreads",
-			new HashMap<String, Object>() {
-				{
-					put("messageBoardSectionId", messageBoardSectionId);
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetMessageBoardSectionMessageBoardThreadsPageMessageBoardSectionMessageBoardThread_getGraphQLField(
+				messageBoardSectionId);
 
 		// No namespace
 
@@ -1114,6 +1105,25 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 				MessageBoardThreadSerDes.toDTOs(
 					messageBoardSectionMessageBoardThreadsJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetMessageBoardSectionMessageBoardThreadsPageMessageBoardSectionMessageBoardThread_getGraphQLField(
+				Long messageBoardSectionId)
+		throws Exception {
+
+		return new GraphQLField(
+			"messageBoardSectionMessageBoardThreads",
+			new HashMap<String, Object>() {
+				{
+					put("messageBoardSectionId", messageBoardSectionId);
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -1811,22 +1821,8 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 
 	@Test
 	public void testGraphQLGetMessageBoardThreadsRankedPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"messageBoardThreadsRanked",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"dateCreated",
-						getGraphQLValue(RandomTestUtil.nextDate()));
-					put(
-						"dateModified",
-						getGraphQLValue(RandomTestUtil.nextDate()));
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetMessageBoardThreadsRankedPageMessageBoardThread_getGraphQLField();
 
 		// No namespace
 
@@ -1887,6 +1883,28 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 			Arrays.asList(
 				MessageBoardThreadSerDes.toDTOs(
 					messageBoardThreadsRankedJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetMessageBoardThreadsRankedPageMessageBoardThread_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"messageBoardThreadsRanked",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"dateCreated",
+						getGraphQLValue(RandomTestUtil.nextDate()));
+					put(
+						"dateModified",
+						getGraphQLValue(RandomTestUtil.nextDate()));
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected MessageBoardThread
@@ -2583,18 +2601,9 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 	public void testGraphQLGetSiteMessageBoardThreadsPage() throws Exception {
 		Long siteId = testGetSiteMessageBoardThreadsPage_getSiteId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"messageBoardThreads",
-			new HashMap<String, Object>() {
-				{
-					put("siteKey", "\"" + siteId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteMessageBoardThreadsPageSiteMessageBoardThread_getGraphQLField(
+				siteId);
 
 		// No namespace
 
@@ -2654,6 +2663,25 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 			Arrays.asList(
 				MessageBoardThreadSerDes.toDTOs(
 					messageBoardThreadsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteMessageBoardThreadsPageSiteMessageBoardThread_getGraphQLField(
+				Long siteId)
+		throws Exception {
+
+		return new GraphQLField(
+			"messageBoardThreads",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -5257,4 +5285,4 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-147785886
+// LIFERAY-REST-BUILDER-HASH:-1181139108

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
@@ -1556,18 +1556,9 @@ public abstract class BaseNavigationMenuResourceTestCase {
 	public void testGraphQLGetSiteNavigationMenusPage() throws Exception {
 		Long siteId = testGetSiteNavigationMenusPage_getSiteId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"navigationMenus",
-			new HashMap<String, Object>() {
-				{
-					put("siteKey", "\"" + siteId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteNavigationMenusPageSiteNavigationMenu_getGraphQLField(
+				siteId);
 
 		// No namespace
 
@@ -1624,6 +1615,25 @@ public abstract class BaseNavigationMenuResourceTestCase {
 			Arrays.asList(
 				NavigationMenuSerDes.toDTOs(
 					navigationMenusJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteNavigationMenusPageSiteNavigationMenu_getGraphQLField(
+				Long siteId)
+		throws Exception {
+
+		return new GraphQLField(
+			"navigationMenus",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3133,4 +3143,4 @@ public abstract class BaseNavigationMenuResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1507684290
+// LIFERAY-REST-BUILDER-HASH:-1593718326

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseSitePageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseSitePageResourceTestCase.java
@@ -623,16 +623,9 @@ public abstract class BaseSitePageResourceTestCase {
 		String friendlyUrlPath =
 			testGetSiteSitePagesExperiencesPage_getFriendlyUrlPath();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"sitePagesExperiences",
-			new HashMap<String, Object>() {
-				{
-					put("siteKey", "\"" + siteId + "\"");
-					put("friendlyUrlPath", "\"" + friendlyUrlPath + "\"");
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteSitePagesExperiencesPageSiteSitePage_getGraphQLField(
+				siteId, friendlyUrlPath);
 
 		// No namespace
 
@@ -692,6 +685,23 @@ public abstract class BaseSitePageResourceTestCase {
 			Arrays.asList(
 				SitePageSerDes.toDTOs(
 					sitePagesExperiencesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteSitePagesExperiencesPageSiteSitePage_getGraphQLField(
+				Long siteId, String friendlyUrlPath)
+		throws Exception {
+
+		return new GraphQLField(
+			"sitePagesExperiences",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+					put("friendlyUrlPath", "\"" + friendlyUrlPath + "\"");
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected SitePage
@@ -1085,18 +1095,8 @@ public abstract class BaseSitePageResourceTestCase {
 	public void testGraphQLGetSiteSitePagesPage() throws Exception {
 		Long siteId = testGetSiteSitePagesPage_getSiteId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"sitePages",
-			new HashMap<String, Object>() {
-				{
-					put("siteKey", "\"" + siteId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteSitePagesPageSiteSitePage_getGraphQLField(siteId);
 
 		// No namespace
 
@@ -1147,6 +1147,25 @@ public abstract class BaseSitePageResourceTestCase {
 			sitePage2,
 			Arrays.asList(
 				SitePageSerDes.toDTOs(sitePagesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteSitePagesPageSiteSitePage_getGraphQLField(
+				Long siteId)
+		throws Exception {
+
+		return new GraphQLField(
+			"sitePages",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2730,4 +2749,4 @@ public abstract class BaseSitePageResourceTestCase {
 		_sitePageResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1297248474
+// LIFERAY-REST-BUILDER-HASH:1005889955

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
@@ -1528,18 +1528,9 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		Long assetLibraryId =
 			testGetAssetLibraryStructuredContentFoldersPage_getAssetLibraryId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"assetLibraryStructuredContentFolders",
-			new HashMap<String, Object>() {
-				{
-					put("assetLibraryId", "\"" + assetLibraryId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAssetLibraryStructuredContentFoldersPageAssetLibraryStructuredContentFolder_getGraphQLField(
+				assetLibraryId);
 
 		// No namespace
 
@@ -1609,6 +1600,25 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 				StructuredContentFolderSerDes.toDTOs(
 					assetLibraryStructuredContentFoldersJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetAssetLibraryStructuredContentFoldersPageAssetLibraryStructuredContentFolder_getGraphQLField(
+				Long assetLibraryId)
+		throws Exception {
+
+		return new GraphQLField(
+			"assetLibraryStructuredContentFolders",
+			new HashMap<String, Object>() {
+				{
+					put("assetLibraryId", "\"" + assetLibraryId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2321,18 +2331,9 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 
 		Long siteId = testGetSiteStructuredContentFoldersPage_getSiteId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"structuredContentFolders",
-			new HashMap<String, Object>() {
-				{
-					put("siteKey", "\"" + siteId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteStructuredContentFoldersPageSiteStructuredContentFolder_getGraphQLField(
+				siteId);
 
 		// No namespace
 
@@ -2393,6 +2394,25 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 			Arrays.asList(
 				StructuredContentFolderSerDes.toDTOs(
 					structuredContentFoldersJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteStructuredContentFoldersPageSiteStructuredContentFolder_getGraphQLField(
+				Long siteId)
+		throws Exception {
+
+		return new GraphQLField(
+			"structuredContentFolders",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3296,20 +3316,9 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		Long parentStructuredContentFolderId =
 			testGetStructuredContentFolderStructuredContentFoldersPage_getParentStructuredContentFolderId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"structuredContentFolderStructuredContentFolders",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"parentStructuredContentFolderId",
-						parentStructuredContentFolderId);
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetStructuredContentFolderStructuredContentFoldersPageStructuredContentFolder_getGraphQLField(
+				parentStructuredContentFolderId);
 
 		// No namespace
 
@@ -3381,6 +3390,27 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 				StructuredContentFolderSerDes.toDTOs(
 					structuredContentFolderStructuredContentFoldersJSONObject.
 						getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetStructuredContentFolderStructuredContentFoldersPageStructuredContentFolder_getGraphQLField(
+				Long parentStructuredContentFolderId)
+		throws Exception {
+
+		return new GraphQLField(
+			"structuredContentFolderStructuredContentFolders",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"parentStructuredContentFolderId",
+						parentStructuredContentFolderId);
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected StructuredContentFolder
@@ -5626,4 +5656,4 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:679966151
+// LIFERAY-REST-BUILDER-HASH:-1611070687

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -1592,18 +1592,9 @@ public abstract class BaseStructuredContentResourceTestCase {
 		Long assetLibraryId =
 			testGetAssetLibraryStructuredContentsPage_getAssetLibraryId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"assetLibraryStructuredContents",
-			new HashMap<String, Object>() {
-				{
-					put("assetLibraryId", "\"" + assetLibraryId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAssetLibraryStructuredContentsPageAssetLibraryStructuredContent_getGraphQLField(
+				assetLibraryId);
 
 		// No namespace
 
@@ -1670,6 +1661,25 @@ public abstract class BaseStructuredContentResourceTestCase {
 				StructuredContentSerDes.toDTOs(
 					assetLibraryStructuredContentsJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetAssetLibraryStructuredContentsPageAssetLibraryStructuredContent_getGraphQLField(
+				Long assetLibraryId)
+		throws Exception {
+
+		return new GraphQLField(
+			"assetLibraryStructuredContents",
+			new HashMap<String, Object>() {
+				{
+					put("assetLibraryId", "\"" + assetLibraryId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3109,18 +3119,9 @@ public abstract class BaseStructuredContentResourceTestCase {
 	public void testGraphQLGetSiteStructuredContentsPage() throws Exception {
 		Long siteId = testGetSiteStructuredContentsPage_getSiteId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"structuredContents",
-			new HashMap<String, Object>() {
-				{
-					put("siteKey", "\"" + siteId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteStructuredContentsPageSiteStructuredContent_getGraphQLField(
+				siteId);
 
 		// No namespace
 
@@ -3177,6 +3178,25 @@ public abstract class BaseStructuredContentResourceTestCase {
 			Arrays.asList(
 				StructuredContentSerDes.toDTOs(
 					structuredContentsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteStructuredContentsPageSiteStructuredContent_getGraphQLField(
+				Long siteId)
+		throws Exception {
+
+		return new GraphQLField(
+			"structuredContents",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -4009,18 +4029,9 @@ public abstract class BaseStructuredContentResourceTestCase {
 		Long structuredContentFolderId =
 			testGetStructuredContentFolderStructuredContentsPage_getStructuredContentFolderId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"structuredContentFolderStructuredContents",
-			new HashMap<String, Object>() {
-				{
-					put("structuredContentFolderId", structuredContentFolderId);
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetStructuredContentFolderStructuredContentsPageStructuredContentFolderStructuredContent_getGraphQLField(
+				structuredContentFolderId);
 
 		// No namespace
 
@@ -4090,6 +4101,25 @@ public abstract class BaseStructuredContentResourceTestCase {
 				StructuredContentSerDes.toDTOs(
 					structuredContentFolderStructuredContentsJSONObject.
 						getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetStructuredContentFolderStructuredContentsPageStructuredContentFolderStructuredContent_getGraphQLField(
+				Long structuredContentFolderId)
+		throws Exception {
+
+		return new GraphQLField(
+			"structuredContentFolderStructuredContents",
+			new HashMap<String, Object>() {
+				{
+					put("structuredContentFolderId", structuredContentFolderId);
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -7267,4 +7297,4 @@ public abstract class BaseStructuredContentResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:74397670
+// LIFERAY-REST-BUILDER-HASH:-1895507926

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
@@ -1087,18 +1087,8 @@ public abstract class BaseWikiNodeResourceTestCase {
 	public void testGraphQLGetSiteWikiNodesPage() throws Exception {
 		Long siteId = testGetSiteWikiNodesPage_getSiteId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"wikiNodes",
-			new HashMap<String, Object>() {
-				{
-					put("siteKey", "\"" + siteId + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteWikiNodesPageSiteWikiNode_getGraphQLField(siteId);
 
 		// No namespace
 
@@ -1149,6 +1139,25 @@ public abstract class BaseWikiNodeResourceTestCase {
 			wikiNode2,
 			Arrays.asList(
 				WikiNodeSerDes.toDTOs(wikiNodesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteWikiNodesPageSiteWikiNode_getGraphQLField(
+				Long siteId)
+		throws Exception {
+
+		return new GraphQLField(
+			"wikiNodes",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3054,4 +3063,4 @@ public abstract class BaseWikiNodeResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:477574466
+// LIFERAY-REST-BUILDER-HASH:-491229712

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageAttachmentResourceTestCase.java
@@ -1248,15 +1248,9 @@ public abstract class BaseWikiPageAttachmentResourceTestCase {
 		Long wikiPageId =
 			testGetWikiPageWikiPageAttachmentsPage_getWikiPageId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"wikiPageWikiPageAttachments",
-			new HashMap<String, Object>() {
-				{
-					put("wikiPageId", wikiPageId);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetWikiPageWikiPageAttachmentsPageWikiPageWikiPageAttachment_getGraphQLField(
+				wikiPageId);
 
 		// No namespace
 
@@ -1317,6 +1311,22 @@ public abstract class BaseWikiPageAttachmentResourceTestCase {
 			Arrays.asList(
 				WikiPageAttachmentSerDes.toDTOs(
 					wikiPageWikiPageAttachmentsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetWikiPageWikiPageAttachmentsPageWikiPageWikiPageAttachment_getGraphQLField(
+				Long wikiPageId)
+		throws Exception {
+
+		return new GraphQLField(
+			"wikiPageWikiPageAttachments",
+			new HashMap<String, Object>() {
+				{
+					put("wikiPageId", wikiPageId);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2688,4 +2698,4 @@ public abstract class BaseWikiPageAttachmentResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:869947813
+// LIFERAY-REST-BUILDER-HASH:-1503383195

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
@@ -1056,18 +1056,9 @@ public abstract class BaseWikiPageResourceTestCase {
 	public void testGraphQLGetWikiNodeWikiPagesPage() throws Exception {
 		Long wikiNodeId = testGetWikiNodeWikiPagesPage_getWikiNodeId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"wikiNodeWikiPages",
-			new HashMap<String, Object>() {
-				{
-					put("wikiNodeId", wikiNodeId);
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetWikiNodeWikiPagesPageWikiNodeWikiPage_getGraphQLField(
+				wikiNodeId);
 
 		// No namespace
 
@@ -1122,6 +1113,25 @@ public abstract class BaseWikiPageResourceTestCase {
 			Arrays.asList(
 				WikiPageSerDes.toDTOs(
 					wikiNodeWikiPagesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetWikiNodeWikiPagesPageWikiNodeWikiPage_getGraphQLField(
+				Long wikiNodeId)
+		throws Exception {
+
+		return new GraphQLField(
+			"wikiNodeWikiPages",
+			new HashMap<String, Object>() {
+				{
+					put("wikiNodeId", wikiNodeId);
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3391,4 +3401,4 @@ public abstract class BaseWikiPageResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2013009374
+// LIFERAY-REST-BUILDER-HASH:589416652

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
@@ -506,17 +506,9 @@ public abstract class BaseFormRecordResourceTestCase {
 	public void testGraphQLGetFormFormRecordsPage() throws Exception {
 		Long formId = testGetFormFormRecordsPage_getFormId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"formFormRecords",
-			new HashMap<String, Object>() {
-				{
-					put("formId", formId);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetFormFormRecordsPageFormFormRecord_getGraphQLField(
+				formId);
 
 		// No namespace
 
@@ -571,6 +563,24 @@ public abstract class BaseFormRecordResourceTestCase {
 			Arrays.asList(
 				FormRecordSerDes.toDTOs(
 					formFormRecordsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetFormFormRecordsPageFormFormRecord_getGraphQLField(
+				Long formId)
+		throws Exception {
+
+		return new GraphQLField(
+			"formFormRecords",
+			new HashMap<String, Object>() {
+				{
+					put("formId", formId);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -1925,4 +1935,4 @@ public abstract class BaseFormRecordResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-313708047
+// LIFERAY-REST-BUILDER-HASH:481599057

--- a/modules/apps/notification/notification-rest-test/src/testIntegration/java/com/liferay/notification/rest/resource/v1_0/test/BaseNotificationQueueEntryResourceTestCase.java
+++ b/modules/apps/notification/notification-rest-test/src/testIntegration/java/com/liferay/notification/rest/resource/v1_0/test/BaseNotificationQueueEntryResourceTestCase.java
@@ -827,17 +827,8 @@ public abstract class BaseNotificationQueueEntryResourceTestCase {
 
 	@Test
 	public void testGraphQLGetNotificationQueueEntriesPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"notificationQueueEntries",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetNotificationQueueEntriesPageNotificationQueueEntry_getGraphQLField();
 
 		// No namespace
 
@@ -898,6 +889,23 @@ public abstract class BaseNotificationQueueEntryResourceTestCase {
 			Arrays.asList(
 				NotificationQueueEntrySerDes.toDTOs(
 					notificationQueueEntriesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetNotificationQueueEntriesPageNotificationQueueEntry_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"notificationQueueEntries",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2733,4 +2741,4 @@ public abstract class BaseNotificationQueueEntryResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:685001564
+// LIFERAY-REST-BUILDER-HASH:-1015216996

--- a/modules/apps/notification/notification-rest-test/src/testIntegration/java/com/liferay/notification/rest/resource/v1_0/test/BaseNotificationTemplateResourceTestCase.java
+++ b/modules/apps/notification/notification-rest-test/src/testIntegration/java/com/liferay/notification/rest/resource/v1_0/test/BaseNotificationTemplateResourceTestCase.java
@@ -1283,17 +1283,8 @@ public abstract class BaseNotificationTemplateResourceTestCase {
 
 	@Test
 	public void testGraphQLGetNotificationTemplatesPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"notificationTemplates",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetNotificationTemplatesPageNotificationTemplate_getGraphQLField();
 
 		// No namespace
 
@@ -1353,6 +1344,23 @@ public abstract class BaseNotificationTemplateResourceTestCase {
 			Arrays.asList(
 				NotificationTemplateSerDes.toDTOs(
 					notificationTemplatesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetNotificationTemplatesPageNotificationTemplate_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"notificationTemplates",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3252,4 +3260,4 @@ public abstract class BaseNotificationTemplateResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1112938660
+// LIFERAY-REST-BUILDER-HASH:118640018

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectActionResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectActionResourceTestCase.java
@@ -1065,20 +1065,9 @@ public abstract class BaseObjectActionResourceTestCase {
 		String externalReferenceCode =
 			testGetObjectDefinitionByExternalReferenceCodeObjectActionsPage_getExternalReferenceCode();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"objectDefinitionByExternalReferenceCodeObjectActions",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"externalReferenceCode",
-						"\"" + externalReferenceCode + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetObjectDefinitionByExternalReferenceCodeObjectActionsPageObjectDefinitionObjectAction_getGraphQLField(
+				externalReferenceCode);
 
 		// No namespace
 
@@ -1149,6 +1138,27 @@ public abstract class BaseObjectActionResourceTestCase {
 				ObjectActionSerDes.toDTOs(
 					objectDefinitionByExternalReferenceCodeObjectActionsJSONObject.
 						getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetObjectDefinitionByExternalReferenceCodeObjectActionsPageObjectDefinitionObjectAction_getGraphQLField(
+				String externalReferenceCode)
+		throws Exception {
+
+		return new GraphQLField(
+			"objectDefinitionByExternalReferenceCodeObjectActions",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"externalReferenceCode",
+						"\"" + externalReferenceCode + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected ObjectAction
@@ -1525,18 +1535,9 @@ public abstract class BaseObjectActionResourceTestCase {
 		Long objectDefinitionId =
 			testGetObjectDefinitionObjectActionsPage_getObjectDefinitionId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"objectDefinitionObjectActions",
-			new HashMap<String, Object>() {
-				{
-					put("objectDefinitionId", objectDefinitionId);
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetObjectDefinitionObjectActionsPageObjectDefinitionObjectAction_getGraphQLField(
+				objectDefinitionId);
 
 		// No namespace
 
@@ -1601,6 +1602,25 @@ public abstract class BaseObjectActionResourceTestCase {
 				ObjectActionSerDes.toDTOs(
 					objectDefinitionObjectActionsJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetObjectDefinitionObjectActionsPageObjectDefinitionObjectAction_getGraphQLField(
+				Long objectDefinitionId)
+		throws Exception {
+
+		return new GraphQLField(
+			"objectDefinitionObjectActions",
+			new HashMap<String, Object>() {
+				{
+					put("objectDefinitionId", objectDefinitionId);
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3257,4 +3277,4 @@ public abstract class BaseObjectActionResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1035755540
+// LIFERAY-REST-BUILDER-HASH:1601857697

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectDefinitionResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectDefinitionResourceTestCase.java
@@ -1255,17 +1255,8 @@ public abstract class BaseObjectDefinitionResourceTestCase {
 
 	@Test
 	public void testGraphQLGetObjectDefinitionsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"objectDefinitions",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetObjectDefinitionsPageObjectDefinition_getGraphQLField();
 
 		// No namespace
 
@@ -1322,6 +1313,23 @@ public abstract class BaseObjectDefinitionResourceTestCase {
 			Arrays.asList(
 				ObjectDefinitionSerDes.toDTOs(
 					objectDefinitionsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetObjectDefinitionsPageObjectDefinition_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"objectDefinitions",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -4262,4 +4270,4 @@ public abstract class BaseObjectDefinitionResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1553812422
+// LIFERAY-REST-BUILDER-HASH:354045556

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectFieldResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectFieldResourceTestCase.java
@@ -861,20 +861,9 @@ public abstract class BaseObjectFieldResourceTestCase {
 		String externalReferenceCode =
 			testGetObjectDefinitionByExternalReferenceCodeObjectFieldsPage_getExternalReferenceCode();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"objectDefinitionByExternalReferenceCodeObjectFields",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"externalReferenceCode",
-						"\"" + externalReferenceCode + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetObjectDefinitionByExternalReferenceCodeObjectFieldsPageObjectDefinitionObjectField_getGraphQLField(
+				externalReferenceCode);
 
 		// No namespace
 
@@ -945,6 +934,27 @@ public abstract class BaseObjectFieldResourceTestCase {
 				ObjectFieldSerDes.toDTOs(
 					objectDefinitionByExternalReferenceCodeObjectFieldsJSONObject.
 						getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetObjectDefinitionByExternalReferenceCodeObjectFieldsPageObjectDefinitionObjectField_getGraphQLField(
+				String externalReferenceCode)
+		throws Exception {
+
+		return new GraphQLField(
+			"objectDefinitionByExternalReferenceCodeObjectFields",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"externalReferenceCode",
+						"\"" + externalReferenceCode + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected ObjectField
@@ -1414,18 +1424,9 @@ public abstract class BaseObjectFieldResourceTestCase {
 		Long objectDefinitionId =
 			testGetObjectDefinitionObjectFieldsPage_getObjectDefinitionId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"objectDefinitionObjectFields",
-			new HashMap<String, Object>() {
-				{
-					put("objectDefinitionId", objectDefinitionId);
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetObjectDefinitionObjectFieldsPageObjectDefinitionObjectField_getGraphQLField(
+				objectDefinitionId);
 
 		// No namespace
 
@@ -1490,6 +1491,25 @@ public abstract class BaseObjectFieldResourceTestCase {
 				ObjectFieldSerDes.toDTOs(
 					objectDefinitionObjectFieldsJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetObjectDefinitionObjectFieldsPageObjectDefinitionObjectField_getGraphQLField(
+				Long objectDefinitionId)
+		throws Exception {
+
+		return new GraphQLField(
+			"objectDefinitionObjectFields",
+			new HashMap<String, Object>() {
+				{
+					put("objectDefinitionId", objectDefinitionId);
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3752,4 +3772,4 @@ public abstract class BaseObjectFieldResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1628128366
+// LIFERAY-REST-BUILDER-HASH:-1132699881

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectFolderResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectFolderResourceTestCase.java
@@ -950,17 +950,8 @@ public abstract class BaseObjectFolderResourceTestCase {
 
 	@Test
 	public void testGraphQLGetObjectFoldersPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"objectFolders",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetObjectFoldersPageObjectFolder_getGraphQLField();
 
 		// No namespace
 
@@ -1015,6 +1006,23 @@ public abstract class BaseObjectFolderResourceTestCase {
 			Arrays.asList(
 				ObjectFolderSerDes.toDTOs(
 					objectFoldersJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetObjectFoldersPageObjectFolder_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"objectFolders",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2280,4 +2288,4 @@ public abstract class BaseObjectFolderResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:277154760
+// LIFERAY-REST-BUILDER-HASH:-1128321070

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectLayoutResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectLayoutResourceTestCase.java
@@ -744,20 +744,9 @@ public abstract class BaseObjectLayoutResourceTestCase {
 		String externalReferenceCode =
 			testGetObjectDefinitionByExternalReferenceCodeObjectLayoutsPage_getExternalReferenceCode();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"objectDefinitionByExternalReferenceCodeObjectLayouts",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"externalReferenceCode",
-						"\"" + externalReferenceCode + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetObjectDefinitionByExternalReferenceCodeObjectLayoutsPageObjectDefinitionObjectLayout_getGraphQLField(
+				externalReferenceCode);
 
 		// No namespace
 
@@ -828,6 +817,27 @@ public abstract class BaseObjectLayoutResourceTestCase {
 				ObjectLayoutSerDes.toDTOs(
 					objectDefinitionByExternalReferenceCodeObjectLayoutsJSONObject.
 						getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetObjectDefinitionByExternalReferenceCodeObjectLayoutsPageObjectDefinitionObjectLayout_getGraphQLField(
+				String externalReferenceCode)
+		throws Exception {
+
+		return new GraphQLField(
+			"objectDefinitionByExternalReferenceCodeObjectLayouts",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"externalReferenceCode",
+						"\"" + externalReferenceCode + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected ObjectLayout
@@ -1204,18 +1214,9 @@ public abstract class BaseObjectLayoutResourceTestCase {
 		Long objectDefinitionId =
 			testGetObjectDefinitionObjectLayoutsPage_getObjectDefinitionId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"objectDefinitionObjectLayouts",
-			new HashMap<String, Object>() {
-				{
-					put("objectDefinitionId", objectDefinitionId);
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetObjectDefinitionObjectLayoutsPageObjectDefinitionObjectLayout_getGraphQLField(
+				objectDefinitionId);
 
 		// No namespace
 
@@ -1280,6 +1281,25 @@ public abstract class BaseObjectLayoutResourceTestCase {
 				ObjectLayoutSerDes.toDTOs(
 					objectDefinitionObjectLayoutsJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetObjectDefinitionObjectLayoutsPageObjectDefinitionObjectLayout_getGraphQLField(
+				Long objectDefinitionId)
+		throws Exception {
+
+		return new GraphQLField(
+			"objectDefinitionObjectLayouts",
+			new HashMap<String, Object>() {
+				{
+					put("objectDefinitionId", objectDefinitionId);
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2846,4 +2866,4 @@ public abstract class BaseObjectLayoutResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1771700183
+// LIFERAY-REST-BUILDER-HASH:-618223422

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectRelationshipResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectRelationshipResourceTestCase.java
@@ -908,20 +908,9 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 		String externalReferenceCode =
 			testGetObjectDefinitionByExternalReferenceCodeObjectRelationshipsPage_getExternalReferenceCode();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"objectDefinitionByExternalReferenceCodeObjectRelationships",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"externalReferenceCode",
-						"\"" + externalReferenceCode + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetObjectDefinitionByExternalReferenceCodeObjectRelationshipsPageObjectDefinitionObjectRelationship_getGraphQLField(
+				externalReferenceCode);
 
 		// No namespace
 
@@ -992,6 +981,27 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 				ObjectRelationshipSerDes.toDTOs(
 					objectDefinitionByExternalReferenceCodeObjectRelationshipsJSONObject.
 						getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetObjectDefinitionByExternalReferenceCodeObjectRelationshipsPageObjectDefinitionObjectRelationship_getGraphQLField(
+				String externalReferenceCode)
+		throws Exception {
+
+		return new GraphQLField(
+			"objectDefinitionByExternalReferenceCodeObjectRelationships",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"externalReferenceCode",
+						"\"" + externalReferenceCode + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected ObjectRelationship
@@ -1514,18 +1524,9 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 		Long objectDefinitionId =
 			testGetObjectDefinitionObjectRelationshipsPage_getObjectDefinitionId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"objectDefinitionObjectRelationships",
-			new HashMap<String, Object>() {
-				{
-					put("objectDefinitionId", objectDefinitionId);
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetObjectDefinitionObjectRelationshipsPageObjectDefinitionObjectRelationship_getGraphQLField(
+				objectDefinitionId);
 
 		// No namespace
 
@@ -1594,6 +1595,25 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 				ObjectRelationshipSerDes.toDTOs(
 					objectDefinitionObjectRelationshipsJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetObjectDefinitionObjectRelationshipsPageObjectDefinitionObjectRelationship_getGraphQLField(
+				Long objectDefinitionId)
+		throws Exception {
+
+		return new GraphQLField(
+			"objectDefinitionObjectRelationships",
+			new HashMap<String, Object>() {
+				{
+					put("objectDefinitionId", objectDefinitionId);
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3832,4 +3852,4 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-963690768
+// LIFERAY-REST-BUILDER-HASH:1949302817

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectValidationRuleResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectValidationRuleResourceTestCase.java
@@ -798,20 +798,9 @@ public abstract class BaseObjectValidationRuleResourceTestCase {
 		String externalReferenceCode =
 			testGetObjectDefinitionByExternalReferenceCodeObjectValidationRulesPage_getExternalReferenceCode();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"objectDefinitionByExternalReferenceCodeObjectValidationRules",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"externalReferenceCode",
-						"\"" + externalReferenceCode + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetObjectDefinitionByExternalReferenceCodeObjectValidationRulesPageObjectDefinitionObjectValidationRule_getGraphQLField(
+				externalReferenceCode);
 
 		// No namespace
 
@@ -882,6 +871,27 @@ public abstract class BaseObjectValidationRuleResourceTestCase {
 				ObjectValidationRuleSerDes.toDTOs(
 					objectDefinitionByExternalReferenceCodeObjectValidationRulesJSONObject.
 						getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetObjectDefinitionByExternalReferenceCodeObjectValidationRulesPageObjectDefinitionObjectValidationRule_getGraphQLField(
+				String externalReferenceCode)
+		throws Exception {
+
+		return new GraphQLField(
+			"objectDefinitionByExternalReferenceCodeObjectValidationRules",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"externalReferenceCode",
+						"\"" + externalReferenceCode + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected ObjectValidationRule
@@ -1303,18 +1313,9 @@ public abstract class BaseObjectValidationRuleResourceTestCase {
 		Long objectDefinitionId =
 			testGetObjectDefinitionObjectValidationRulesPage_getObjectDefinitionId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"objectDefinitionObjectValidationRules",
-			new HashMap<String, Object>() {
-				{
-					put("objectDefinitionId", objectDefinitionId);
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetObjectDefinitionObjectValidationRulesPageObjectDefinitionObjectValidationRule_getGraphQLField(
+				objectDefinitionId);
 
 		// No namespace
 
@@ -1384,6 +1385,25 @@ public abstract class BaseObjectValidationRuleResourceTestCase {
 				ObjectValidationRuleSerDes.toDTOs(
 					objectDefinitionObjectValidationRulesJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetObjectDefinitionObjectValidationRulesPageObjectDefinitionObjectValidationRule_getGraphQLField(
+				Long objectDefinitionId)
+		throws Exception {
+
+		return new GraphQLField(
+			"objectDefinitionObjectValidationRules",
+			new HashMap<String, Object>() {
+				{
+					put("objectDefinitionId", objectDefinitionId);
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3397,4 +3417,4 @@ public abstract class BaseObjectValidationRuleResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-830770811
+// LIFERAY-REST-BUILDER-HASH:-429495116

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectViewResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectViewResourceTestCase.java
@@ -725,20 +725,9 @@ public abstract class BaseObjectViewResourceTestCase {
 		String externalReferenceCode =
 			testGetObjectDefinitionByExternalReferenceCodeObjectViewsPage_getExternalReferenceCode();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"objectDefinitionByExternalReferenceCodeObjectViews",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"externalReferenceCode",
-						"\"" + externalReferenceCode + "\"");
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetObjectDefinitionByExternalReferenceCodeObjectViewsPageObjectDefinitionObjectView_getGraphQLField(
+				externalReferenceCode);
 
 		// No namespace
 
@@ -809,6 +798,27 @@ public abstract class BaseObjectViewResourceTestCase {
 				ObjectViewSerDes.toDTOs(
 					objectDefinitionByExternalReferenceCodeObjectViewsJSONObject.
 						getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetObjectDefinitionByExternalReferenceCodeObjectViewsPageObjectDefinitionObjectView_getGraphQLField(
+				String externalReferenceCode)
+		throws Exception {
+
+		return new GraphQLField(
+			"objectDefinitionByExternalReferenceCodeObjectViews",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"externalReferenceCode",
+						"\"" + externalReferenceCode + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected ObjectView
@@ -1170,18 +1180,9 @@ public abstract class BaseObjectViewResourceTestCase {
 		Long objectDefinitionId =
 			testGetObjectDefinitionObjectViewsPage_getObjectDefinitionId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"objectDefinitionObjectViews",
-			new HashMap<String, Object>() {
-				{
-					put("objectDefinitionId", objectDefinitionId);
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetObjectDefinitionObjectViewsPageObjectDefinitionObjectView_getGraphQLField(
+				objectDefinitionId);
 
 		// No namespace
 
@@ -1242,6 +1243,25 @@ public abstract class BaseObjectViewResourceTestCase {
 			Arrays.asList(
 				ObjectViewSerDes.toDTOs(
 					objectDefinitionObjectViewsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetObjectDefinitionObjectViewsPageObjectDefinitionObjectView_getGraphQLField(
+				Long objectDefinitionId)
+		throws Exception {
+
+		return new GraphQLField(
+			"objectDefinitionObjectViews",
+			new HashMap<String, Object>() {
+				{
+					put("objectDefinitionId", objectDefinitionId);
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2866,4 +2886,4 @@ public abstract class BaseObjectViewResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-53522340
+// LIFERAY-REST-BUILDER-HASH:-300855407

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseInstanceResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseInstanceResourceTestCase.java
@@ -764,21 +764,9 @@ public abstract class BaseInstanceResourceTestCase {
 	public void testGraphQLGetProcessInstancesPage() throws Exception {
 		Long processId = testGetProcessInstancesPage_getProcessId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"processInstances",
-			new HashMap<String, Object>() {
-				{
-					put("processId", processId);
-					put("dateEnd", getGraphQLValue(RandomTestUtil.nextDate()));
-					put(
-						"dateStart",
-						getGraphQLValue(RandomTestUtil.nextDate()));
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetProcessInstancesPageProcessInstance_getGraphQLField(
+				processId);
 
 		// No namespace
 
@@ -833,6 +821,28 @@ public abstract class BaseInstanceResourceTestCase {
 			Arrays.asList(
 				InstanceSerDes.toDTOs(
 					processInstancesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetProcessInstancesPageProcessInstance_getGraphQLField(
+				Long processId)
+		throws Exception {
+
+		return new GraphQLField(
+			"processInstances",
+			new HashMap<String, Object>() {
+				{
+					put("processId", processId);
+					put("dateEnd", getGraphQLValue(RandomTestUtil.nextDate()));
+					put(
+						"dateStart",
+						getGraphQLValue(RandomTestUtil.nextDate()));
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2367,4 +2377,4 @@ public abstract class BaseInstanceResourceTestCase {
 			_instanceResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-591524331
+// LIFERAY-REST-BUILDER-HASH:-1291175069

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseNodeResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseNodeResourceTestCase.java
@@ -349,15 +349,9 @@ public abstract class BaseNodeResourceTestCase {
 	public void testGraphQLGetProcessNodesPage() throws Exception {
 		Long processId = testGetProcessNodesPage_getProcessId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"processNodes",
-			new HashMap<String, Object>() {
-				{
-					put("processId", processId);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetProcessNodesPageProcessNode_getGraphQLField(
+				processId);
 
 		// No namespace
 
@@ -406,6 +400,22 @@ public abstract class BaseNodeResourceTestCase {
 			node2,
 			Arrays.asList(
 				NodeSerDes.toDTOs(processNodesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetProcessNodesPageProcessNode_getGraphQLField(
+				Long processId)
+		throws Exception {
+
+		return new GraphQLField(
+			"processNodes",
+			new HashMap<String, Object>() {
+				{
+					put("processId", processId);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -1568,4 +1578,4 @@ public abstract class BaseNodeResourceTestCase {
 		_nodeResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1151069399
+// LIFERAY-REST-BUILDER-HASH:645732421

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResourceTestCase.java
@@ -513,17 +513,8 @@ public abstract class BaseSLAResourceTestCase {
 	public void testGraphQLGetProcessSLAsPage() throws Exception {
 		Long processId = testGetProcessSLAsPage_getProcessId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"processSLAs",
-			new HashMap<String, Object>() {
-				{
-					put("processId", processId);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetProcessSLAsPageProcessSLA_getGraphQLField(processId);
 
 		// No namespace
 
@@ -572,6 +563,24 @@ public abstract class BaseSLAResourceTestCase {
 			sla2,
 			Arrays.asList(
 				SLASerDes.toDTOs(processSLAsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetProcessSLAsPageProcessSLA_getGraphQLField(
+				Long processId)
+		throws Exception {
+
+		return new GraphQLField(
+			"processSLAs",
+			new HashMap<String, Object>() {
+				{
+					put("processId", processId);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2106,4 +2115,4 @@ public abstract class BaseSLAResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1539871616
+// LIFERAY-REST-BUILDER-HASH:961617990

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseTaskResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseTaskResourceTestCase.java
@@ -529,15 +529,9 @@ public abstract class BaseTaskResourceTestCase {
 	public void testGraphQLGetProcessTasksPage() throws Exception {
 		Long processId = testGetProcessTasksPage_getProcessId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"processTasks",
-			new HashMap<String, Object>() {
-				{
-					put("processId", processId);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetProcessTasksPageProcessTask_getGraphQLField(
+				processId);
 
 		// No namespace
 
@@ -586,6 +580,22 @@ public abstract class BaseTaskResourceTestCase {
 			task2,
 			Arrays.asList(
 				TaskSerDes.toDTOs(processTasksJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetProcessTasksPageProcessTask_getGraphQLField(
+				Long processId)
+		throws Exception {
+
+		return new GraphQLField(
+			"processTasks",
+			new HashMap<String, Object>() {
+				{
+					put("processId", processId);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2157,4 +2167,4 @@ public abstract class BaseTaskResourceTestCase {
 		_taskResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-339135258
+// LIFERAY-REST-BUILDER-HASH:-2007048050

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPBlueprintResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPBlueprintResourceTestCase.java
@@ -1194,17 +1194,8 @@ public abstract class BaseSXPBlueprintResourceTestCase {
 
 	@Test
 	public void testGraphQLGetSXPBlueprintsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"sXPBlueprints",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSXPBlueprintsPageSXPBlueprint_getGraphQLField();
 
 		// No namespace
 
@@ -1259,6 +1250,23 @@ public abstract class BaseSXPBlueprintResourceTestCase {
 			Arrays.asList(
 				SXPBlueprintSerDes.toDTOs(
 					sXPBlueprintsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSXPBlueprintsPageSXPBlueprint_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"sXPBlueprints",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3049,4 +3057,4 @@ public abstract class BaseSXPBlueprintResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1951086847
+// LIFERAY-REST-BUILDER-HASH:-1000985083

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPElementResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPElementResourceTestCase.java
@@ -1155,17 +1155,8 @@ public abstract class BaseSXPElementResourceTestCase {
 
 	@Test
 	public void testGraphQLGetSXPElementsPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"sXPElements",
-			new HashMap<String, Object>() {
-				{
-					put("search", null);
-					put("page", 1);
-					put("pageSize", 10);
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSXPElementsPageSXPElement_getGraphQLField();
 
 		// No namespace
 
@@ -1220,6 +1211,23 @@ public abstract class BaseSXPElementResourceTestCase {
 			Arrays.asList(
 				SXPElementSerDes.toDTOs(
 					sXPElementsJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSXPElementsPageSXPElement_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"sXPElements",
+			new HashMap<String, Object>() {
+				{
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3071,4 +3079,4 @@ public abstract class BaseSXPElementResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:2136473269
+// LIFERAY-REST-BUILDER-HASH:-1716442847

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseBatchTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseBatchTestEntityResourceTestCase.java
@@ -402,14 +402,8 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 
 	@Test
 	public void testGraphQLGetBatchTestEntitiesPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"batchTestEntities",
-			new HashMap<String, Object>() {
-				{
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetBatchTestEntitiesPageBatchTestEntity_getGraphQLField();
 
 		// No namespace
 
@@ -466,6 +460,20 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 			Arrays.asList(
 				BatchTestEntitySerDes.toDTOs(
 					batchTestEntitiesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetBatchTestEntitiesPageBatchTestEntity_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"batchTestEntities",
+			new HashMap<String, Object>() {
+				{
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2131,4 +2139,4 @@ public abstract class BaseBatchTestEntityResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1993247939
+// LIFERAY-REST-BUILDER-HASH:-787316301

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseCompanyTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseCompanyTestEntityResourceTestCase.java
@@ -432,14 +432,8 @@ public abstract class BaseCompanyTestEntityResourceTestCase {
 
 	@Test
 	public void testGraphQLGetCompanyTestEntitiesPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"companyTestEntities",
-			new HashMap<String, Object>() {
-				{
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetCompanyTestEntitiesPageCompanyTestEntity_getGraphQLField();
 
 		// No namespace
 
@@ -499,6 +493,20 @@ public abstract class BaseCompanyTestEntityResourceTestCase {
 			Arrays.asList(
 				CompanyTestEntitySerDes.toDTOs(
 					companyTestEntitiesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetCompanyTestEntitiesPageCompanyTestEntity_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"companyTestEntities",
+			new HashMap<String, Object>() {
+				{
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2422,4 +2430,4 @@ public abstract class BaseCompanyTestEntityResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1675477083
+// LIFERAY-REST-BUILDER-HASH:-1177669793

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCAssetLibraryTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCAssetLibraryTestEntityResourceTestCase.java
@@ -565,17 +565,9 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 		String assetLibraryExternalReferenceCode =
 			testGetAssetLibraryERCAssetLibraryTestEntitiesPage_getAssetLibraryExternalReferenceCode();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"assetLibraryERCAssetLibraryTestEntities",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"assetLibraryExternalReferenceCode",
-						"\"" + assetLibraryExternalReferenceCode + "\"");
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAssetLibraryERCAssetLibraryTestEntitiesPageAssetLibraryERCAssetLibraryTestEntity_getGraphQLField(
+				assetLibraryExternalReferenceCode);
 
 		// No namespace
 
@@ -647,6 +639,24 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 				ERCAssetLibraryTestEntitySerDes.toDTOs(
 					assetLibraryERCAssetLibraryTestEntitiesJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetAssetLibraryERCAssetLibraryTestEntitiesPageAssetLibraryERCAssetLibraryTestEntity_getGraphQLField(
+				String assetLibraryExternalReferenceCode)
+		throws Exception {
+
+		return new GraphQLField(
+			"assetLibraryERCAssetLibraryTestEntities",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"assetLibraryExternalReferenceCode",
+						"\"" + assetLibraryExternalReferenceCode + "\"");
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2295,4 +2305,4 @@ public abstract class BaseERCAssetLibraryTestEntityResourceTestCase {
 		ERCAssetLibraryTestEntityResource _ercAssetLibraryTestEntityResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2019162337
+// LIFERAY-REST-BUILDER-HASH:85682754

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCScopedTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCScopedTestEntityResourceTestCase.java
@@ -818,17 +818,9 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 		String assetLibraryExternalReferenceCode =
 			testGetAssetLibraryERCScopedTestEntitiesPage_getAssetLibraryExternalReferenceCode();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"assetLibraryERCScopedTestEntities",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"assetLibraryExternalReferenceCode",
-						"\"" + assetLibraryExternalReferenceCode + "\"");
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAssetLibraryERCScopedTestEntitiesPageAssetLibraryERCScopedTestEntity_getGraphQLField(
+				assetLibraryExternalReferenceCode);
 
 		// No namespace
 
@@ -895,6 +887,24 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 				ERCScopedTestEntitySerDes.toDTOs(
 					assetLibraryERCScopedTestEntitiesJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetAssetLibraryERCScopedTestEntitiesPageAssetLibraryERCScopedTestEntity_getGraphQLField(
+				String assetLibraryExternalReferenceCode)
+		throws Exception {
+
+		return new GraphQLField(
+			"assetLibraryERCScopedTestEntities",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"assetLibraryExternalReferenceCode",
+						"\"" + assetLibraryExternalReferenceCode + "\"");
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -1202,17 +1212,8 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 
 	@Test
 	public void testGraphQLGetERCScopedTestEntitiesPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"eRCScopedTestEntities",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"roleNames",
-						getGraphQLValue(RandomTestUtil.randomString()));
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetERCScopedTestEntitiesPageERCScopedTestEntity_getGraphQLField();
 
 		// No namespace
 
@@ -1272,6 +1273,23 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 			Arrays.asList(
 				ERCScopedTestEntitySerDes.toDTOs(
 					eRCScopedTestEntitiesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetERCScopedTestEntitiesPageERCScopedTestEntity_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"eRCScopedTestEntities",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"roleNames",
+						getGraphQLValue(RandomTestUtil.randomString()));
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	protected ERCScopedTestEntity
@@ -1466,17 +1484,9 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 		String siteExternalReferenceCode =
 			testGetSiteERCScopedTestEntitiesPage_getSiteExternalReferenceCode();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"siteERCScopedTestEntities",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"siteExternalReferenceCode",
-						"\"" + siteExternalReferenceCode + "\"");
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteERCScopedTestEntitiesPageSiteERCScopedTestEntity_getGraphQLField(
+				siteExternalReferenceCode);
 
 		// No namespace
 
@@ -1537,6 +1547,24 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 			Arrays.asList(
 				ERCScopedTestEntitySerDes.toDTOs(
 					siteERCScopedTestEntitiesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteERCScopedTestEntitiesPageSiteERCScopedTestEntity_getGraphQLField(
+				String siteExternalReferenceCode)
+		throws Exception {
+
+		return new GraphQLField(
+			"siteERCScopedTestEntities",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"siteExternalReferenceCode",
+						"\"" + siteExternalReferenceCode + "\"");
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -3590,4 +3618,4 @@ public abstract class BaseERCScopedTestEntityResourceTestCase {
 		ERCScopedTestEntityResource _ercScopedTestEntityResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1660322624
+// LIFERAY-REST-BUILDER-HASH:1771221312

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCSiteTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseERCSiteTestEntityResourceTestCase.java
@@ -491,17 +491,9 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 		String siteExternalReferenceCode =
 			testGetSiteERCSiteTestEntitiesPage_getSiteExternalReferenceCode();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"eRCSiteTestEntities",
-			new HashMap<String, Object>() {
-				{
-					put(
-						"siteExternalReferenceCode",
-						"\"" + siteExternalReferenceCode + "\"");
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteERCSiteTestEntitiesPageSiteERCSiteTestEntity_getGraphQLField(
+				siteExternalReferenceCode);
 
 		// No namespace
 
@@ -561,6 +553,24 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 			Arrays.asList(
 				ERCSiteTestEntitySerDes.toDTOs(
 					eRCSiteTestEntitiesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteERCSiteTestEntitiesPageSiteERCSiteTestEntity_getGraphQLField(
+				String siteExternalReferenceCode)
+		throws Exception {
+
+		return new GraphQLField(
+			"eRCSiteTestEntities",
+			new HashMap<String, Object>() {
+				{
+					put(
+						"siteExternalReferenceCode",
+						"\"" + siteExternalReferenceCode + "\"");
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2104,4 +2114,4 @@ public abstract class BaseERCSiteTestEntityResourceTestCase {
 		ERCSiteTestEntityResource _ercSiteTestEntityResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:996020699
+// LIFERAY-REST-BUILDER-HASH:-1214262218

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseScopedTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseScopedTestEntityResourceTestCase.java
@@ -659,15 +659,9 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 		Long assetLibraryId =
 			testGetAssetLibraryScopedTestEntitiesPage_getAssetLibraryId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"assetLibraryScopedTestEntities",
-			new HashMap<String, Object>() {
-				{
-					put("assetLibraryId", "\"" + assetLibraryId + "\"");
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetAssetLibraryScopedTestEntitiesPageAssetLibraryScopedTestEntity_getGraphQLField(
+				assetLibraryId);
 
 		// No namespace
 
@@ -734,6 +728,22 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 				ScopedTestEntitySerDes.toDTOs(
 					assetLibraryScopedTestEntitiesJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetAssetLibraryScopedTestEntitiesPageAssetLibraryScopedTestEntity_getGraphQLField(
+				Long assetLibraryId)
+		throws Exception {
+
+		return new GraphQLField(
+			"assetLibraryScopedTestEntities",
+			new HashMap<String, Object>() {
+				{
+					put("assetLibraryId", "\"" + assetLibraryId + "\"");
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -1002,15 +1012,9 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 	public void testGraphQLGetSiteScopedTestEntitiesPage() throws Exception {
 		Long siteId = testGetSiteScopedTestEntitiesPage_getSiteId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"scopedTestEntities",
-			new HashMap<String, Object>() {
-				{
-					put("siteKey", "\"" + siteId + "\"");
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteScopedTestEntitiesPageSiteScopedTestEntity_getGraphQLField(
+				siteId);
 
 		// No namespace
 
@@ -1067,6 +1071,22 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 			Arrays.asList(
 				ScopedTestEntitySerDes.toDTOs(
 					scopedTestEntitiesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteScopedTestEntitiesPageSiteScopedTestEntity_getGraphQLField(
+				Long siteId)
+		throws Exception {
+
+		return new GraphQLField(
+			"scopedTestEntities",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2731,4 +2751,4 @@ public abstract class BaseScopedTestEntityResourceTestCase {
 		ScopedTestEntityResource _scopedTestEntityResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1522530996
+// LIFERAY-REST-BUILDER-HASH:79652918

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseSharedInternalModelBatchTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseSharedInternalModelBatchTestEntityResourceTestCase.java
@@ -408,14 +408,8 @@ public abstract class BaseSharedInternalModelBatchTestEntityResourceTestCase {
 	public void testGraphQLGetSharedInternalModelBatchTestEntitiesPage()
 		throws Exception {
 
-		GraphQLField graphQLField = new GraphQLField(
-			"sharedInternalModelBatchTestEntities",
-			new HashMap<String, Object>() {
-				{
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSharedInternalModelBatchTestEntitiesPageSharedInternalModelBatchTestEntity_getGraphQLField();
 
 		// No namespace
 
@@ -485,6 +479,20 @@ public abstract class BaseSharedInternalModelBatchTestEntityResourceTestCase {
 				SharedInternalModelBatchTestEntitySerDes.toDTOs(
 					sharedInternalModelBatchTestEntitiesJSONObject.getString(
 						"items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSharedInternalModelBatchTestEntitiesPageSharedInternalModelBatchTestEntity_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"sharedInternalModelBatchTestEntities",
+			new HashMap<String, Object>() {
+				{
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -1744,4 +1752,4 @@ public abstract class BaseSharedInternalModelBatchTestEntityResourceTestCase {
 			_sharedInternalModelBatchTestEntityResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1365181772
+// LIFERAY-REST-BUILDER-HASH:355778140

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseSiteTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseSiteTestEntityResourceTestCase.java
@@ -490,15 +490,9 @@ public abstract class BaseSiteTestEntityResourceTestCase {
 	public void testGraphQLGetSiteSiteTestEntitiesPage() throws Exception {
 		Long siteId = testGetSiteSiteTestEntitiesPage_getSiteId();
 
-		GraphQLField graphQLField = new GraphQLField(
-			"siteTestEntities",
-			new HashMap<String, Object>() {
-				{
-					put("siteKey", "\"" + siteId + "\"");
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetSiteSiteTestEntitiesPageSiteSiteTestEntity_getGraphQLField(
+				siteId);
 
 		// No namespace
 
@@ -555,6 +549,22 @@ public abstract class BaseSiteTestEntityResourceTestCase {
 			Arrays.asList(
 				SiteTestEntitySerDes.toDTOs(
 					siteTestEntitiesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetSiteSiteTestEntitiesPageSiteSiteTestEntity_getGraphQLField(
+				Long siteId)
+		throws Exception {
+
+		return new GraphQLField(
+			"siteTestEntities",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2531,4 +2541,4 @@ public abstract class BaseSiteTestEntityResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-431871166
+// LIFERAY-REST-BUILDER-HASH:-109985034

--- a/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseTestEntityResourceTestCase.java
+++ b/modules/util/portal-tools-rest-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/rest/builder/test/resource/v1_0/test/BaseTestEntityResourceTestCase.java
@@ -496,14 +496,8 @@ public abstract class BaseTestEntityResourceTestCase {
 
 	@Test
 	public void testGraphQLGetTestEntitiesPage() throws Exception {
-		GraphQLField graphQLField = new GraphQLField(
-			"testEntities",
-			new HashMap<String, Object>() {
-				{
-				}
-			},
-			new GraphQLField("items", getGraphQLFields()),
-			new GraphQLField("page"), new GraphQLField("totalCount"));
+		GraphQLField graphQLField =
+			testGraphQLGetTestEntitiesPageTestEntity_getGraphQLField();
 
 		// No namespace
 
@@ -558,6 +552,20 @@ public abstract class BaseTestEntityResourceTestCase {
 			Arrays.asList(
 				TestEntitySerDes.toDTOs(
 					testEntitiesJSONObject.getString("items"))));
+	}
+
+	protected GraphQLField
+			testGraphQLGetTestEntitiesPageTestEntity_getGraphQLField()
+		throws Exception {
+
+		return new GraphQLField(
+			"testEntities",
+			new HashMap<String, Object>() {
+				{
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
 	}
 
 	@Test
@@ -2510,4 +2518,4 @@ public abstract class BaseTestEntityResourceTestCase {
 		_vulcanCRUDItemDelegateBuilderRegistry;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1918766857
+// LIFERAY-REST-BUILDER-HASH:-85513533

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -2254,45 +2254,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 							${javaMethodParameter.parameterType} ${javaMethodParameter.parameterName} = test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}();
 						</#list>
 
-						GraphQLField graphQLField = new GraphQLField(
-							"${propertyName}",
-							new HashMap<String, Object>() {
-								{
-									<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
-										<#if stringUtil.equals(javaMethodParameter.parameterName, "keywords")>
-											put("${javaMethodParameter.parameterName}", null);
-										<#elseif stringUtil.equals(javaMethodParameter.parameterName, "pagination")>
-											put("page", 1);
-											put("pageSize", 10);
-										<#elseif stringUtil.equals(javaMethodParameter.parameterName, "search")>
-											put("${javaMethodParameter.parameterName}", null);
-										<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation)>
-											<#if stringUtil.equals(javaMethodParameter.parameterName, "siteId")>
-												put("siteKey", <@getQuotedString unquotedString="${javaMethodParameter.parameterName}" />);
-											<#else>
-												put("${javaMethodParameter.parameterName}",
-													<#if stringUtil.equals(javaMethodParameter.parameterType, "java.lang.String") || stringUtil.equals(javaMethodParameter.parameterName, "assetLibraryId")>
-														<@getQuotedString unquotedString = "${javaMethodParameter.parameterName}" />
-													<#else>
-														${javaMethodParameter.parameterName}
-													</#if>
-												);
-											</#if>
-										<#elseif stringUtil.equals(javaMethodParameter.parameterType, "java.util.Date")>
-											put("${javaMethodParameter.parameterName}", getGraphQLValue(RandomTestUtil.nextDate()));
-										<#elseif stringUtil.equals(javaMethodParameter.parameterType, "java.lang.String")>
-											put("${javaMethodParameter.parameterName}", getGraphQLValue(RandomTestUtil.randomString()));
-										<#elseif stringUtil.equals(javaMethodParameter.parameterType, "boolean")>
-											put("${javaMethodParameter.parameterName}", getGraphQLValue(RandomTestUtil.randomBoolean()));
-										<#elseif stringUtil.equals(javaMethodParameter.parameterType, "double")>
-											put("${javaMethodParameter.parameterName}", getGraphQLValue(RandomTestUtil.randomDouble()));
-										<#elseif stringUtil.equals(javaMethodParameter.parameterType, "long")>
-											put("${javaMethodParameter.parameterName}", getGraphQLValue(RandomTestUtil.randomLong()));
-										</#if>
-									</#list>
-								}
-							},
-							new GraphQLField("items", getGraphQLFields()), new GraphQLField("page"), new GraphQLField("totalCount"));
+						GraphQLField graphQLField = testGraphQL${javaMethodSignature.methodName?cap_first}${parentSchemaName}${schemaName}_getGraphQLField(<#list javaMethodSignature.pathJavaMethodParameters as javaMethodParameter>${javaMethodParameter.parameterName}<#sep>, </#list>);
 
 						<#if !configYAML.getGraphQLNamespace()?has_content>
 							// No namespace
@@ -2385,6 +2347,48 @@ public abstract class Base${schemaName}ResourceTestCase {
 							assertContains(${schemaVarName}1, Arrays.asList(${schemaName}SerDes.toDTOs(${propertyName}JSONObject.getString("items"))));
 							assertContains(${schemaVarName}2, Arrays.asList(${schemaName}SerDes.toDTOs(${propertyName}JSONObject.getString("items"))));
 						</#if>
+					}
+
+					protected GraphQLField testGraphQL${javaMethodSignature.methodName?cap_first}${parentSchemaName}${schemaName}_getGraphQLField(<#list javaMethodSignature.pathJavaMethodParameters as javaMethodParameter>${javaMethodParameter.parameterType} ${javaMethodParameter.parameterName}<#sep>, </#list>) throws Exception {
+						return new GraphQLField(
+							"${propertyName}",
+							new HashMap<String, Object>() {
+								{
+									<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
+										<#if stringUtil.equals(javaMethodParameter.parameterName, "keywords")>
+											put("${javaMethodParameter.parameterName}", null);
+										<#elseif stringUtil.equals(javaMethodParameter.parameterName, "pagination")>
+											put("page", 1);
+											put("pageSize", 10);
+										<#elseif stringUtil.equals(javaMethodParameter.parameterName, "search")>
+											put("${javaMethodParameter.parameterName}", null);
+										<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation)>
+											<#if stringUtil.equals(javaMethodParameter.parameterName, "siteId")>
+												put("siteKey", <@getQuotedString unquotedString="${javaMethodParameter.parameterName}" />);
+											<#else>
+												put("${javaMethodParameter.parameterName}",
+													<#if stringUtil.equals(javaMethodParameter.parameterType, "java.lang.String") || stringUtil.equals(javaMethodParameter.parameterName, "assetLibraryId")>
+														<@getQuotedString unquotedString = "${javaMethodParameter.parameterName}" />
+													<#else>
+														${javaMethodParameter.parameterName}
+													</#if>
+												);
+											</#if>
+										<#elseif stringUtil.equals(javaMethodParameter.parameterType, "java.util.Date")>
+											put("${javaMethodParameter.parameterName}", getGraphQLValue(RandomTestUtil.nextDate()));
+										<#elseif stringUtil.equals(javaMethodParameter.parameterType, "java.lang.String")>
+											put("${javaMethodParameter.parameterName}", getGraphQLValue(RandomTestUtil.randomString()));
+										<#elseif stringUtil.equals(javaMethodParameter.parameterType, "boolean")>
+											put("${javaMethodParameter.parameterName}", getGraphQLValue(RandomTestUtil.randomBoolean()));
+										<#elseif stringUtil.equals(javaMethodParameter.parameterType, "double")>
+											put("${javaMethodParameter.parameterName}", getGraphQLValue(RandomTestUtil.randomDouble()));
+										<#elseif stringUtil.equals(javaMethodParameter.parameterType, "long")>
+											put("${javaMethodParameter.parameterName}", getGraphQLValue(RandomTestUtil.randomLong()));
+										</#if>
+									</#list>
+								}
+							},
+							new GraphQLField("items", getGraphQLFields()), new GraphQLField("page"), new GraphQLField("totalCount"));
 					}
 				</#if>
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94433

## What Is Being Fixed

The REST Builder generated `Base*ResourceTestCase` classes built the GraphQL page query inline inside the generated `testGraphQL...Page` method, leaving no seam for a hand-written resource test to customize that query. Because of this, several GraphQL page tests could not be implemented and stayed skipped — for example the skipped `testGraphQL...` cases on UserAccount.

## How It Is Being Fixed

The `base_resource_test_case.ftl` template now extracts the `GraphQLField` construction into a dedicated overridable `protected` method, `testGraphQL<Method><Parent><Schema>_getGraphQLField(...)`, and the generated page test calls that method instead of inlining the field. A subclass can now override the method to supply the correct query. Every REST Builder module was regenerated to pick up the new seam. `UserAccountResourceTest` overrides it to provide a sorted, paginated `userAccounts` query, which enables the previously skipped GraphQL page test.

## PR Check

**pr-check: PASS** — tested on `aae3f3a4c8f0726ab5ac54a3c61831ee5599951f`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "aae3f3a4c8f0726ab5ac54a3c61831ee5599951f"} -->
