### PR TITLE
LPD-98802 Skip git worktree remove when the worktree is already gone

### DIFF
--- a/.claude/hooks/worktree-remove.sh
+++ b/.claude/hooks/worktree-remove.sh
@@ -33,7 +33,10 @@ function main {
 
 	_drop_database "${worktree_path}" "${bundles_dir}"
 
-	git worktree remove "${worktree_path}"
+	if git worktree list --porcelain | grep --fixed-strings --line-regexp --quiet "worktree ${worktree_path}"
+	then
+		git worktree remove "${worktree_path}"
+	fi
 }
 
 main "${@}"


### PR DESCRIPTION
## Summary
- Fixes FleetView job deletion failing with "worktree could not be removed (WorktreeRemove hook failed)" when the job's own worktree was already removed (directory + git registration) before the hook ran
- `.claude/hooks/worktree-remove.sh` now checks whether the path is still a registered git worktree before calling `git worktree remove`, making the hook idempotent

## Test plan
- [x] Simulated the hook with a stale, already-removed worktree path — exits 0 instead of erroring
- [x] Confirmed the guard still matches a currently-registered worktree path

https://liferay.atlassian.net/browse/LPD-98802