### PR TITLE
LPD-99358 Append osgi/test to module.framework.auto.deploy.dirs

### DIFF
--- a/.claude/hooks/worktree-create.sh
+++ b/.claude/hooks/worktree-create.sh
@@ -36,6 +36,7 @@ function main {
 	_set_portal_home
 	_set_portal_http_address
 	_set_poshi_url
+	_set_test_auto_deploy_dir
 	_set_test_integration_port
 	_set_tomcat_ports
 
@@ -439,6 +440,39 @@ function _set_property {
 	fi
 
 	echo "${key}=${value}" >> "${file}"
+}
+
+function _set_test_auto_deploy_dir {
+	local source_file="${WORKTREE_DIR}/portal-impl/src/portal.properties"
+
+	[[ -f ${source_file} ]] || _die "${source_file} is missing."
+
+	local current_value
+
+	current_value="$(awk '
+		/^[[:space:]]*module\.framework\.auto\.deploy\.dirs=/ {
+			in_block = 1
+
+			sub(/^[[:space:]]*module\.framework\.auto\.deploy\.dirs=/, "")
+		}
+
+		in_block {
+			gsub(/[[:space:]]/, "")
+
+			if (sub(/\\$/, "")) {
+				printf "%s", $0
+			}
+			else {
+				print $0
+
+				exit
+			}
+		}
+	' "${source_file}")"
+
+	[[ -n ${current_value} ]] || _die "Unable to read module.framework.auto.deploy.dirs from ${source_file}."
+
+	_set_property "${BUNDLES_DIR}/portal-ext.properties" module.framework.auto.deploy.dirs "${current_value},\${module.framework.base.dir}/test"
 }
 
 function _set_test_integration_port {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99358

Extracts the Arquillian `osgi/test` auto-deploy fix from #647 (commit 15634e6c) into its own ticket and PR, so it can land independently of the other worktree-create.sh improvements.

Without the override, `osgi/test/` is not scanned at Tomcat boot. The `*-test-util` bundles deployed there (Arquillian connector, test fixtures) only activate when `gradlew testIntegration` copies them into `osgi/modules/`. That copy races with `SocketState.getServerSocket()` in the test JVM, which binds the Arquillian port from `_START_PORT=32764` upward; the connector loses the bind and Tomcat exits via `System.exit(-10)`. Appending `${module.framework.base.dir}/test` to `module.framework.auto.deploy.dirs` (reading the live value at hook runtime) makes the test bundles scan at boot.

Original change authored by Nícolas Moura (@nicolas-sss).
