### PR TITLE
LPD-101661 Send Cross Cutting Properties as an array

### DIFF
--- a/.claude/skills/jira-bug/SKILL.md
+++ b/.claude/skills/jira-bug/SKILL.md
@@ -30,7 +30,7 @@ The LPD project requires the following fields. Apply these defaults unless the u
 
 - **Affects Version**: `Master` (ID: `16660`).
 - **Component**: Infer from the code area. Fetch the LPD project components and select the one whose name matches the relevant area or keyword.
-- **Cross Cutting Properties** (`customfield_10979`): `None` (ID: `14468`).
+- **Cross Cutting Properties** (`customfield_10979`): `None` (ID: `14468`). Send the value as an array, `[{"id": "14468"}]`. Jira rejects a bare object with `Specify the value for Cross Cutting Properties in an array`.
 
 ## Create the Ticket
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101661

## What Is Being Fixed

The `jira-bug` skill documented the required Cross Cutting Properties field (`customfield_10979`) as a plain value, `None (ID: 14468)`, which reads as a single object. The Jira REST API rejects that shape with `Specify the value for Cross Cutting Properties in an array`, so every first attempt to create an LPD bug failed and had to be retried with the value wrapped in an array. This surfaced while filing LPD-101616.

## How It Is Being Fixed

The field's entry under **Required Fields** now states that the value is sent as an array and shows the literal shape, `[{"id": "14468"}]`, along with the exact error Jira returns for a bare object so the symptom is recognizable if it regresses.

## PR Check

**pr-check: SKIPPED** — Requested by the author. The change is a Markdown-only edit to a Claude skill, with no code, build, or test impact.

<!-- pr-check {"reason": "Requested by the author. The change is a Markdown-only edit to a Claude skill, with no code, build, or test impact.", "result": "skipped", "sha": "646274bf4bc5b164a5d3ff9e5f582bf039296264"} -->
